### PR TITLE
Added OneDrive support

### DIFF
--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -13,6 +13,18 @@
 		4A05900E2451A145008831F9 /* CloudItemList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A05900D2451A145008831F9 /* CloudItemList.swift */; };
 		4A0590122451A180008831F9 /* CloudItemMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0590112451A180008831F9 /* CloudItemMetadata.swift */; };
 		4A05901D2451DD26008831F9 /* CloudProviderError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A05901C2451DD26008831F9 /* CloudProviderError.swift */; };
+		4A1A11542629A44B00DAF62F /* MSGraphClientModels in Frameworks */ = {isa = PBXBuildFile; productRef = 4A1A11532629A44B00DAF62F /* MSGraphClientModels */; };
+		4A1A115A2629A4A200DAF62F /* MSGraphClientSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 4A1A11592629A4A200DAF62F /* MSGraphClientSDK */; };
+		4A1A11602629A51400DAF62F /* MSGraphMSALAuthProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 4A1A115F2629A51400DAF62F /* MSGraphMSALAuthProvider */; };
+		4A1A11652629A52F00DAF62F /* OneDriveCloudProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A11642629A52F00DAF62F /* OneDriveCloudProvider.swift */; };
+		4A1A11742629ACCA00DAF62F /* OneDriveCredential.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A11732629ACCA00DAF62F /* OneDriveCredential.swift */; };
+		4A1A11792629ACD500DAF62F /* OneDriveAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A11782629ACD500DAF62F /* OneDriveAuthenticator.swift */; };
+		4A1A117E2629AD8F00DAF62F /* OneDriveSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A117D2629AD8F00DAF62F /* OneDriveSetup.swift */; };
+		4A1A1183262B078E00DAF62F /* OneDriveError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A1182262B078E00DAF62F /* OneDriveError.swift */; };
+		4A1A118F262D95E600DAF62F /* OneDriveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A118E262D95E600DAF62F /* OneDriveItem.swift */; };
+		4A1A1194262EC46E00DAF62F /* OneDriveIdentifierCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A1193262EC46E00DAF62F /* OneDriveIdentifierCache.swift */; };
+		4A30DAF62636D79C004B5B4E /* OneDriveCloudProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C90202636D59400ADB421 /* OneDriveCloudProviderTests.swift */; };
+		4A3896CE2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3896CD2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift */; };
 		4A3A39692615F96900F16B26 /* DropboxExponentialBackOffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A39682615F96900F16B26 /* DropboxExponentialBackOffTests.swift */; };
 		4A3A396E2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A396D2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift */; };
 		4A3A39742615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A39732615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift */; };
@@ -66,6 +78,7 @@
 		4ACA640D2615FF9800D19304 /* CloudPath+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA63FF2615FF9700D19304 /* CloudPath+Extension.swift */; };
 		4ACA640E2615FF9800D19304 /* LocalFileSystemProviderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA64012615FF9700D19304 /* LocalFileSystemProviderIntegrationTests.swift */; };
 		4ACA64262616054F00D19304 /* IntegrationTestSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA64252616054F00D19304 /* IntegrationTestSecrets.swift */; };
+		4AD55339263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD55338263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift */; };
 		740A7FDD24C5DFC9000216E7 /* LocalFileSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740A7FDC24C5DFC9000216E7 /* LocalFileSystemTests.swift */; };
 		740C144E249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740C144D249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift */; };
 		7416F22324F594B20074DA8E /* TLSCertificate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7416F22224F594B20074DA8E /* TLSCertificate.swift */; };
@@ -151,6 +164,15 @@
 		4A05900D2451A145008831F9 /* CloudItemList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudItemList.swift; sourceTree = "<group>"; };
 		4A0590112451A180008831F9 /* CloudItemMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudItemMetadata.swift; sourceTree = "<group>"; };
 		4A05901C2451DD26008831F9 /* CloudProviderError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudProviderError.swift; sourceTree = "<group>"; };
+		4A0C90202636D59400ADB421 /* OneDriveCloudProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveCloudProviderTests.swift; sourceTree = "<group>"; };
+		4A1A11642629A52F00DAF62F /* OneDriveCloudProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveCloudProvider.swift; sourceTree = "<group>"; };
+		4A1A11732629ACCA00DAF62F /* OneDriveCredential.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveCredential.swift; sourceTree = "<group>"; };
+		4A1A11782629ACD500DAF62F /* OneDriveAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveAuthenticator.swift; sourceTree = "<group>"; };
+		4A1A117D2629AD8F00DAF62F /* OneDriveSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveSetup.swift; sourceTree = "<group>"; };
+		4A1A1182262B078E00DAF62F /* OneDriveError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveError.swift; sourceTree = "<group>"; };
+		4A1A118E262D95E600DAF62F /* OneDriveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveItem.swift; sourceTree = "<group>"; };
+		4A1A1193262EC46E00DAF62F /* OneDriveIdentifierCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveIdentifierCache.swift; sourceTree = "<group>"; };
+		4A3896CD2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveAuthenticationProvider.swift; sourceTree = "<group>"; };
 		4A3A39682615F96900F16B26 /* DropboxExponentialBackOffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxExponentialBackOffTests.swift; sourceTree = "<group>"; };
 		4A3A396D2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDriveIdentifierCacheTests.swift; sourceTree = "<group>"; };
 		4A3A39732615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDriveCloudProviderTests.swift; sourceTree = "<group>"; };
@@ -200,6 +222,7 @@
 		4ACA63FF2615FF9700D19304 /* CloudPath+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CloudPath+Extension.swift"; sourceTree = "<group>"; };
 		4ACA64012615FF9700D19304 /* LocalFileSystemProviderIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalFileSystemProviderIntegrationTests.swift; sourceTree = "<group>"; };
 		4ACA64252616054F00D19304 /* IntegrationTestSecrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTestSecrets.swift; sourceTree = "<group>"; };
+		4AD55338263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MSGraphDriveItem+CloudItemType.swift"; sourceTree = "<group>"; };
 		740A7FDC24C5DFC9000216E7 /* LocalFileSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileSystemTests.swift; sourceTree = "<group>"; };
 		740C144D249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat7ShorteningProviderDecorator.swift; sourceTree = "<group>"; };
 		7416F22224F594B20074DA8E /* TLSCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLSCertificate.swift; sourceTree = "<group>"; };
@@ -319,6 +342,7 @@
 				4A567AF02615C2DE002C4D82 /* Dropbox */,
 				4A567B172615C8BB002C4D82 /* GoogleDrive */,
 				7471BDAC24865B6F000D05FC /* LocalFileSystem */,
+				4A1A11692629A53300DAF62F /* OneDrive */,
 				748A42B424AA228200DEB6D0 /* WebDAV */,
 			);
 			path = CryptomatorCloudAccess;
@@ -333,6 +357,7 @@
 				4A3A396C2615F97600F16B26 /* Dropbox */,
 				4A3A39772615F9AA00F16B26 /* GoogleDrive */,
 				740A7FDB24C5DFB3000216E7 /* LocalFileSystem */,
+				4A0C90222636D59800ADB421 /* OneDrive */,
 				748420C124B8A1F800D84E58 /* WebDAV */,
 			);
 			path = CryptomatorCloudAccessTests;
@@ -351,6 +376,30 @@
 				4A05901C2451DD26008831F9 /* CloudProviderError.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		4A0C90222636D59800ADB421 /* OneDrive */ = {
+			isa = PBXGroup;
+			children = (
+				4A0C90202636D59400ADB421 /* OneDriveCloudProviderTests.swift */,
+			);
+			path = OneDrive;
+			sourceTree = "<group>";
+		};
+		4A1A11692629A53300DAF62F /* OneDrive */ = {
+			isa = PBXGroup;
+			children = (
+				4A3896CD2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift */,
+				4A1A11782629ACD500DAF62F /* OneDriveAuthenticator.swift */,
+				4A1A11642629A52F00DAF62F /* OneDriveCloudProvider.swift */,
+				4A1A11732629ACCA00DAF62F /* OneDriveCredential.swift */,
+				4A1A1182262B078E00DAF62F /* OneDriveError.swift */,
+				4A1A1193262EC46E00DAF62F /* OneDriveIdentifierCache.swift */,
+				4A1A118E262D95E600DAF62F /* OneDriveItem.swift */,
+				4A1A117D2629AD8F00DAF62F /* OneDriveSetup.swift */,
+				4AD55338263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift */,
+			);
+			path = OneDrive;
 			sourceTree = "<group>";
 		};
 		4A3A396C2615F97600F16B26 /* Dropbox */ = {
@@ -710,6 +759,9 @@
 				4A567B192615C917002C4D82 /* GTMAppAuth */,
 				4A567B362615CAAC002C4D82 /* GTMSessionFetcher */,
 				4A567B3B2615CB00002C4D82 /* AppAuth */,
+				4A1A11532629A44B00DAF62F /* MSGraphClientModels */,
+				4A1A11592629A4A200DAF62F /* MSGraphClientSDK */,
+				4A1A115F2629A51400DAF62F /* MSGraphMSALAuthProvider */,
 			);
 			productName = CloudAccess;
 			productReference = 4A058FF124519FFC008831F9 /* CryptomatorCloudAccess.framework */;
@@ -792,6 +844,9 @@
 				4A567B182615C917002C4D82 /* XCRemoteSwiftPackageReference "GTMAppAuth" */,
 				4A567B352615CAAC002C4D82 /* XCRemoteSwiftPackageReference "gtm-session-fetcher" */,
 				4A567B3A2615CB00002C4D82 /* XCRemoteSwiftPackageReference "AppAuth-iOS" */,
+				4A1A11522629A44B00DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-models" */,
+				4A1A11582629A4A100DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc" */,
+				4A1A115E2629A51400DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-auth" */,
 			);
 			productRefGroup = 4A058FF224519FFC008831F9 /* Products */;
 			projectDirPath = "";
@@ -906,6 +961,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				748BD4CC24B4D3820001CA8C /* Date+RFC822.swift in Sources */,
+				4A1A1183262B078E00DAF62F /* OneDriveError.swift in Sources */,
 				740C144E249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift in Sources */,
 				74FD6C4824F6F3AA00C8D3C4 /* VaultFormat6ShorteningProviderDecorator.swift in Sources */,
 				4A567B222615CA24002C4D82 /* GoogleDriveIdentifierCache.swift in Sources */,
@@ -913,15 +969,20 @@
 				4A567AED2615C2D7002C4D82 /* DropboxAuthenticator.swift in Sources */,
 				748A42B624AA231000DEB6D0 /* WebDAVProvider.swift in Sources */,
 				748A42BA24AA34F300DEB6D0 /* WebDAVCredential.swift in Sources */,
+				4A1A11742629ACCA00DAF62F /* OneDriveCredential.swift in Sources */,
 				9ED0E61D24617C2800FDB438 /* VaultFormat7ProviderDecorator.swift in Sources */,
 				7477BD5C24AE24E6005F2F31 /* TLSCertificateValidator.swift in Sources */,
+				4A1A118F262D95E600DAF62F /* OneDriveItem.swift in Sources */,
 				4A567B712615D946002C4D82 /* DropboxSetup.swift in Sources */,
 				9E969456249B8493000DB743 /* VaultFormat7ShortenedNameCache.swift in Sources */,
 				7471BDAE24865B6F000D05FC /* LocalFileSystemProvider.swift in Sources */,
+				4A1A1194262EC46E00DAF62F /* OneDriveIdentifierCache.swift in Sources */,
+				4A1A11652629A52F00DAF62F /* OneDriveCloudProvider.swift in Sources */,
 				4A6E5DED252DC9480091E76D /* WebDAVSession.swift in Sources */,
 				74CF2E6C254B6683006266D6 /* VaultFormatError.swift in Sources */,
 				4A0590122451A180008831F9 /* CloudItemMetadata.swift in Sources */,
 				7416F22924F659550074DA8E /* VaultFormat6ProviderDecorator.swift in Sources */,
+				4A3896CE2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift in Sources */,
 				4A05901D2451DD26008831F9 /* CloudProviderError.swift in Sources */,
 				4A05900E2451A145008831F9 /* CloudItemList.swift in Sources */,
 				9EE62A0D247D54760089DAF7 /* CloudProvider+Convenience.swift in Sources */,
@@ -934,12 +995,15 @@
 				4A567B2E2615CA5C002C4D82 /* GoogleDriveCredential.swift in Sources */,
 				74FD6C4624F6F39E00C8D3C4 /* VaultFormat6ShortenedNameCache.swift in Sources */,
 				7416F22324F594B20074DA8E /* TLSCertificate.swift in Sources */,
+				4A1A117E2629AD8F00DAF62F /* OneDriveSetup.swift in Sources */,
 				4A567B2A2615CA4B002C4D82 /* GoogleDriveConstants.swift in Sources */,
 				4A567B0C2615C6DA002C4D82 /* DropboxCredential.swift in Sources */,
+				4A1A11792629ACD500DAF62F /* OneDriveAuthenticator.swift in Sources */,
 				748BD4CA24B4B1D50001CA8C /* PropfindResponseParser.swift in Sources */,
 				4A567B322615CA6E002C4D82 /* GoogleDriveError.swift in Sources */,
 				748A42B824AA231D00DEB6D0 /* WebDAVAuthenticator.swift in Sources */,
 				4A567B262615CA34002C4D82 /* GoogleDriveCloudProvider.swift in Sources */,
+				4AD55339263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift in Sources */,
 				748A42C024AB424500DEB6D0 /* WebDAVClient.swift in Sources */,
 				4A567B082615C6AF002C4D82 /* DropboxCloudProvider.swift in Sources */,
 				74C596E824F022AF00FFD17E /* CloudPath.swift in Sources */,
@@ -968,6 +1032,7 @@
 				7416F22F24F678BE0074DA8E /* VaultFormat6ProviderDecoratorTests.swift in Sources */,
 				7460B7722518F984004AEB56 /* VaultFormat6ShorteningProviderDecoratorTests.swift in Sources */,
 				7494505F24BC5C3300149816 /* PropfindResponseParserTests.swift in Sources */,
+				4A30DAF62636D79C004B5B4E /* OneDriveCloudProviderTests.swift in Sources */,
 				9EE62A10247D54E90089DAF7 /* CloudProvider+ConvenienceTests.swift in Sources */,
 				9ED0E622246180AB00FDB438 /* VaultFormat7CloudProviderMock.swift in Sources */,
 				7416F22D24F678AF0074DA8E /* VaultFormat6CloudProviderMockTests.swift in Sources */,
@@ -1323,6 +1388,30 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		4A1A11522629A44B00DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-models" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/phil1995/msgraph-sdk-objc-models.git";
+			requirement = {
+				branch = "1.3.0-fixed";
+				kind = branch;
+			};
+		};
+		4A1A11582629A4A100DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/phil1995/msgraph-sdk-objc.git";
+			requirement = {
+				branch = "swift-pm";
+				kind = branch;
+			};
+		};
+		4A1A115E2629A51400DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-auth" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/phil1995/msgraph-sdk-objc-auth.git";
+			requirement = {
+				branch = "swift-pm";
+				kind = branch;
+			};
+		};
 		4A567AF32615C47B002C4D82 /* XCRemoteSwiftPackageReference "dropbox-sdk-obj-c" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/phil1995/dropbox-sdk-obj-c.git";
@@ -1390,6 +1479,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4A1A11532629A44B00DAF62F /* MSGraphClientModels */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A1A11522629A44B00DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-models" */;
+			productName = MSGraphClientModels;
+		};
+		4A1A11592629A4A200DAF62F /* MSGraphClientSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A1A11582629A4A100DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc" */;
+			productName = MSGraphClientSDK;
+		};
+		4A1A115F2629A51400DAF62F /* MSGraphMSALAuthProvider */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A1A115E2629A51400DAF62F /* XCRemoteSwiftPackageReference "msgraph-sdk-objc-auth" */;
+			productName = MSGraphMSALAuthProvider;
+		};
 		4A567AF42615C47B002C4D82 /* ObjectiveDropboxOfficial */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4A567AF32615C47B002C4D82 /* XCRemoteSwiftPackageReference "dropbox-sdk-obj-c" */;

--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -1038,7 +1038,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -f ./.integration-test-secrets.sh ]; then\n  source ./.integration-test-secrets.sh\nelse\n  echo \"warning: .integration-test-secrets.sh could not be found, please see README for instructions\"\nfi\n/usr/libexec/PlistBuddy -c \"Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 ${ONEDRIVE_REDIRECT_URI}\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
+			shellScript = "if [ -f ./.integration-test-secrets.sh ]; then\n  source ./.integration-test-secrets.sh\nelse\n  echo \"warning: .integration-test-secrets.sh could not be found, please see README for instructions\"\nfi\n/usr/libexec/PlistBuddy -c \"Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 ${ONEDRIVE_REDIRECT_URI_SCHEME}\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
 		};
 		4ACA641B2616025B00D19304 /* Create IntegrationTestSecrets */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -23,12 +23,20 @@
 		4A1A1183262B078E00DAF62F /* OneDriveError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A1182262B078E00DAF62F /* OneDriveError.swift */; };
 		4A1A118F262D95E600DAF62F /* OneDriveItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A118E262D95E600DAF62F /* OneDriveItem.swift */; };
 		4A1A1194262EC46E00DAF62F /* OneDriveIdentifierCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1A1193262EC46E00DAF62F /* OneDriveIdentifierCache.swift */; };
+		4A2C6317264181730078EEC6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4A2C62E02641554F0078EEC6 /* Assets.xcassets */; };
+		4A2C6318264181730078EEC6 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A2C62E12641554F0078EEC6 /* LaunchScreen.storyboard */; };
+		4A2C6319264181730078EEC6 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4A2C62E32641554F0078EEC6 /* Main.storyboard */; };
+		4A2C631F264181890078EEC6 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C62DF2641554F0078EEC6 /* ViewController.swift */; };
+		4A2C6320264181890078EEC6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C62E52641554F0078EEC6 /* AppDelegate.swift */; };
+		4A2C6321264181890078EEC6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C62E72641554F0078EEC6 /* SceneDelegate.swift */; };
 		4A30DAF62636D79C004B5B4E /* OneDriveCloudProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C90202636D59400ADB421 /* OneDriveCloudProviderTests.swift */; };
 		4A3896CE2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3896CD2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift */; };
 		4A3A39692615F96900F16B26 /* DropboxExponentialBackOffTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A39682615F96900F16B26 /* DropboxExponentialBackOffTests.swift */; };
 		4A3A396E2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A396D2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift */; };
 		4A3A39742615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A3A39732615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift */; };
 		4A4074A0252F432900D583C3 /* URLProtocolMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A40749F252F432900D583C3 /* URLProtocolMock.swift */; };
+		4A41D2432641938A00B5D787 /* VaultFormat6OneDriveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A41D2422641938A00B5D787 /* VaultFormat6OneDriveIntegrationTests.swift */; };
+		4A41D2492641960B00B5D787 /* VaultFormat7OneDriveIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A41D2482641960B00B5D787 /* VaultFormat7OneDriveIntegrationTests.swift */; };
 		4A567AED2615C2D7002C4D82 /* DropboxAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A567AEC2615C2D7002C4D82 /* DropboxAuthenticator.swift */; };
 		4A567AF52615C47B002C4D82 /* ObjectiveDropboxOfficial in Frameworks */ = {isa = PBXBuildFile; productRef = 4A567AF42615C47B002C4D82 /* ObjectiveDropboxOfficial */; };
 		4A567AFA2615C58F002C4D82 /* GoogleAPIClientForREST_Drive in Frameworks */ = {isa = PBXBuildFile; productRef = 4A567AF92615C58F002C4D82 /* GoogleAPIClientForREST_Drive */; };
@@ -78,7 +86,9 @@
 		4ACA640D2615FF9800D19304 /* CloudPath+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA63FF2615FF9700D19304 /* CloudPath+Extension.swift */; };
 		4ACA640E2615FF9800D19304 /* LocalFileSystemProviderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA64012615FF9700D19304 /* LocalFileSystemProviderIntegrationTests.swift */; };
 		4ACA64262616054F00D19304 /* IntegrationTestSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ACA64252616054F00D19304 /* IntegrationTestSecrets.swift */; };
+		4AD5530426393EF800126046 /* OneDriveKeychainItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5530326393EF800126046 /* OneDriveKeychainItem.swift */; };
 		4AD55339263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD55338263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift */; };
+		4AFC5F67263190BB00744715 /* OneDriveCloudProviderIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFC5F66263190BB00744715 /* OneDriveCloudProviderIntegrationTests.swift */; };
 		740A7FDD24C5DFC9000216E7 /* LocalFileSystemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740A7FDC24C5DFC9000216E7 /* LocalFileSystemTests.swift */; };
 		740C144E249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740C144D249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift */; };
 		740C5879262F800A00F63423 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = 740C5878262F800A00F63423 /* JOSESwift */; };
@@ -150,6 +160,13 @@
 			remoteGlobalIDString = 4A058FF024519FFC008831F9;
 			remoteInfo = CloudAccess;
 		};
+		4A30DB402636E7EC004B5B4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4A058FE824519FFC008831F9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4A30DB232636E7B6004B5B4E;
+			remoteInfo = CryptomatorCloudAccessIntegrationTestsHost;
+		};
 		4ACA63942615FDFF00D19304 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A058FE824519FFC008831F9 /* Project object */;
@@ -177,11 +194,21 @@
 		4A1A1182262B078E00DAF62F /* OneDriveError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveError.swift; sourceTree = "<group>"; };
 		4A1A118E262D95E600DAF62F /* OneDriveItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveItem.swift; sourceTree = "<group>"; };
 		4A1A1193262EC46E00DAF62F /* OneDriveIdentifierCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveIdentifierCache.swift; sourceTree = "<group>"; };
+		4A2C62DF2641554F0078EEC6 /* ViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		4A2C62E02641554F0078EEC6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		4A2C62E22641554F0078EEC6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		4A2C62E42641554F0078EEC6 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		4A2C62E52641554F0078EEC6 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		4A2C62E62641554F0078EEC6 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		4A2C62E72641554F0078EEC6 /* SceneDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		4A30DB242636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CryptomatorCloudAccessIntegrationTestsHost.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A3896CD2632D65B00BA3E88 /* OneDriveAuthenticationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveAuthenticationProvider.swift; sourceTree = "<group>"; };
 		4A3A39682615F96900F16B26 /* DropboxExponentialBackOffTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxExponentialBackOffTests.swift; sourceTree = "<group>"; };
 		4A3A396D2615F98B00F16B26 /* GoogleDriveIdentifierCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDriveIdentifierCacheTests.swift; sourceTree = "<group>"; };
 		4A3A39732615F9A600F16B26 /* GoogleDriveCloudProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleDriveCloudProviderTests.swift; sourceTree = "<group>"; };
 		4A40749F252F432900D583C3 /* URLProtocolMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLProtocolMock.swift; sourceTree = "<group>"; };
+		4A41D2422641938A00B5D787 /* VaultFormat6OneDriveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat6OneDriveIntegrationTests.swift; sourceTree = "<group>"; };
+		4A41D2482641960B00B5D787 /* VaultFormat7OneDriveIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat7OneDriveIntegrationTests.swift; sourceTree = "<group>"; };
 		4A567AEC2615C2D7002C4D82 /* DropboxAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxAuthenticator.swift; sourceTree = "<group>"; };
 		4A567B032615C689002C4D82 /* DropboxClientSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxClientSetup.swift; sourceTree = "<group>"; };
 		4A567B072615C6AF002C4D82 /* DropboxCloudProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropboxCloudProvider.swift; sourceTree = "<group>"; };
@@ -227,7 +254,9 @@
 		4ACA63FF2615FF9700D19304 /* CloudPath+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CloudPath+Extension.swift"; sourceTree = "<group>"; };
 		4ACA64012615FF9700D19304 /* LocalFileSystemProviderIntegrationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocalFileSystemProviderIntegrationTests.swift; sourceTree = "<group>"; };
 		4ACA64252616054F00D19304 /* IntegrationTestSecrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntegrationTestSecrets.swift; sourceTree = "<group>"; };
+		4AD5530326393EF800126046 /* OneDriveKeychainItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveKeychainItem.swift; sourceTree = "<group>"; };
 		4AD55338263ABA4200126046 /* MSGraphDriveItem+CloudItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MSGraphDriveItem+CloudItemType.swift"; sourceTree = "<group>"; };
+		4AFC5F66263190BB00744715 /* OneDriveCloudProviderIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OneDriveCloudProviderIntegrationTests.swift; sourceTree = "<group>"; };
 		740A7FDC24C5DFC9000216E7 /* LocalFileSystemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileSystemTests.swift; sourceTree = "<group>"; };
 		740C144D249B4F2B008CA3E0 /* VaultFormat7ShorteningProviderDecorator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat7ShorteningProviderDecorator.swift; sourceTree = "<group>"; };
 		7416F22224F594B20074DA8E /* TLSCertificate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TLSCertificate.swift; sourceTree = "<group>"; };
@@ -293,12 +322,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				74F9355D251F67A3001F4ADA /* CryptomatorCryptoLib in Frameworks */,
+				4A1A11602629A51400DAF62F /* MSGraphMSALAuthProvider in Frameworks */,
 				74F93562251F6822001F4ADA /* GRDB in Frameworks */,
 				740C5879262F800A00F63423 /* JOSESwift in Frameworks */,
 				4A567B3C2615CB00002C4D82 /* AppAuth in Frameworks */,
 				4A567AF52615C47B002C4D82 /* ObjectiveDropboxOfficial in Frameworks */,
 				74F93567251F6863001F4ADA /* Promises in Frameworks */,
 				4A567AFA2615C58F002C4D82 /* GoogleAPIClientForREST_Drive in Frameworks */,
+				4A1A11542629A44B00DAF62F /* MSGraphClientModels in Frameworks */,
+				4A1A115A2629A4A200DAF62F /* MSGraphClientSDK in Frameworks */,
 				4A567B372615CAAC002C4D82 /* GTMSessionFetcher in Frameworks */,
 				4A567B1A2615C917002C4D82 /* GTMAppAuth in Frameworks */,
 			);
@@ -309,6 +341,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A058FFB24519FFC008831F9 /* CryptomatorCloudAccess.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4A30DB212636E7B6004B5B4E /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -338,6 +377,7 @@
 				4A058FF124519FFC008831F9 /* CryptomatorCloudAccess.framework */,
 				4A058FFA24519FFC008831F9 /* CryptomatorCloudAccessTests.xctest */,
 				4ACA638E2615FDFF00D19304 /* CryptomatorCloudAccessIntegrationTests.xctest */,
+				4A30DB242636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -412,6 +452,20 @@
 			path = OneDrive;
 			sourceTree = "<group>";
 		};
+		4A2C62DE2641554F0078EEC6 /* CryptomatorCloudAccessIntegrationTestsHost */ = {
+			isa = PBXGroup;
+			children = (
+				4A2C62DF2641554F0078EEC6 /* ViewController.swift */,
+				4A2C62E02641554F0078EEC6 /* Assets.xcassets */,
+				4A2C62E12641554F0078EEC6 /* LaunchScreen.storyboard */,
+				4A2C62E32641554F0078EEC6 /* Main.storyboard */,
+				4A2C62E52641554F0078EEC6 /* AppDelegate.swift */,
+				4A2C62E62641554F0078EEC6 /* Info.plist */,
+				4A2C62E72641554F0078EEC6 /* SceneDelegate.swift */,
+			);
+			path = CryptomatorCloudAccessIntegrationTestsHost;
+			sourceTree = "<group>";
+		};
 		4A3A396C2615F97600F16B26 /* Dropbox */ = {
 			isa = PBXGroup;
 			children = (
@@ -470,6 +524,7 @@
 				4ACA63F32615FF9700D19304 /* Google Drive */,
 				4ACA64002615FF9700D19304 /* LocalFileSystem */,
 				4ACA63F72615FF9700D19304 /* WebDAV */,
+				4AFC5F6B263190C000744715 /* OneDrive */,
 			);
 			path = CryptomatorCloudAccessIntegrationTests;
 			sourceTree = "<group>";
@@ -491,6 +546,7 @@
 				4ACA63D02615FF1600D19304 /* VaultFormat6GoogleDriveIntegrationTests.swift */,
 				4ACA63C62615FED700D19304 /* VaultFormat6LocalFileSystemProviderIntegrationTests.swift */,
 				4ACA63D52615FF2E00D19304 /* VaultFormat6WebDAVIntegrationTests.swift */,
+				4A41D2422641938A00B5D787 /* VaultFormat6OneDriveIntegrationTests.swift */,
 			);
 			path = VaultFormat6;
 			sourceTree = "<group>";
@@ -502,6 +558,7 @@
 				4ACA63E22615FF6400D19304 /* VaultFormat7GoogleDriveIntegrationTests.swift */,
 				4ACA63E52615FF6400D19304 /* VaultFormat7LocalFileSystemProviderIntegrationTests.swift */,
 				4ACA63E32615FF6400D19304 /* VaultFormat7WebDAVIntegrationTests.swift */,
+				4A41D2482641960B00B5D787 /* VaultFormat7OneDriveIntegrationTests.swift */,
 			);
 			path = VaultFormat7;
 			sourceTree = "<group>";
@@ -552,6 +609,15 @@
 				4ACA64012615FF9700D19304 /* LocalFileSystemProviderIntegrationTests.swift */,
 			);
 			path = LocalFileSystem;
+			sourceTree = "<group>";
+		};
+		4AFC5F6B263190C000744715 /* OneDrive */ = {
+			isa = PBXGroup;
+			children = (
+				4AFC5F66263190BB00744715 /* OneDriveCloudProviderIntegrationTests.swift */,
+				4AD5530326393EF800126046 /* OneDriveKeychainItem.swift */,
+			);
+			path = OneDrive;
 			sourceTree = "<group>";
 		};
 		740A7FDB24C5DFB3000216E7 /* LocalFileSystem */ = {
@@ -704,6 +770,7 @@
 		74F9354C251F66F8001F4ADA /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				4A2C62DE2641554F0078EEC6 /* CryptomatorCloudAccessIntegrationTestsHost */,
 				4ACA638F2615FDFF00D19304 /* CryptomatorCloudAccessIntegrationTests */,
 				4A058FFE24519FFC008831F9 /* CryptomatorCloudAccessTests */,
 			);
@@ -808,6 +875,24 @@
 			productReference = 4A058FFA24519FFC008831F9 /* CryptomatorCloudAccessTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		4A30DB232636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4A30DB352636E7B7004B5B4E /* Build configuration list for PBXNativeTarget "CryptomatorCloudAccessIntegrationTestsHost" */;
+			buildPhases = (
+				4A30DB202636E7B6004B5B4E /* Sources */,
+				4A30DB212636E7B6004B5B4E /* Frameworks */,
+				4A30DB222636E7B6004B5B4E /* Resources */,
+				4A30DB462636E84E004B5B4E /* Set OneDrive URLScheme */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CryptomatorCloudAccessIntegrationTestsHost;
+			productName = CryptomatorCloudAccessIntegrationTestsHost;
+			productReference = 4A30DB242636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost.app */;
+			productType = "com.apple.product-type.application";
+		};
 		4ACA638D2615FDFF00D19304 /* CryptomatorCloudAccessIntegrationTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4ACA63982615FDFF00D19304 /* Build configuration list for PBXNativeTarget "CryptomatorCloudAccessIntegrationTests" */;
@@ -821,6 +906,7 @@
 			);
 			dependencies = (
 				4ACA63952615FDFF00D19304 /* PBXTargetDependency */,
+				4A30DB412636E7EC004B5B4E /* PBXTargetDependency */,
 			);
 			name = CryptomatorCloudAccessIntegrationTests;
 			productName = CryptomatorCloudAccessIntegrationTests;
@@ -844,8 +930,12 @@
 					4A058FF924519FFC008831F9 = {
 						CreatedOnToolsVersion = 11.4;
 					};
+					4A30DB232636E7B6004B5B4E = {
+						CreatedOnToolsVersion = 12.4;
+					};
 					4ACA638D2615FDFF00D19304 = {
 						CreatedOnToolsVersion = 12.4;
+						TestTargetID = 4A30DB232636E7B6004B5B4E;
 					};
 				};
 			};
@@ -879,6 +969,7 @@
 				4A058FF024519FFC008831F9 /* CryptomatorCloudAccess */,
 				4A058FF924519FFC008831F9 /* CryptomatorCloudAccessTests */,
 				4ACA638D2615FDFF00D19304 /* CryptomatorCloudAccessIntegrationTests */,
+				4A30DB232636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost */,
 			);
 		};
 /* End PBXProject section */
@@ -910,6 +1001,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4A30DB222636E7B6004B5B4E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A2C6317264181730078EEC6 /* Assets.xcassets in Resources */,
+				4A2C6318264181730078EEC6 /* LaunchScreen.storyboard in Resources */,
+				4A2C6319264181730078EEC6 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4ACA638C2615FDFF00D19304 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -920,6 +1021,25 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		4A30DB462636E84E004B5B4E /* Set OneDrive URLScheme */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(INFOPLIST_PATH)",
+			);
+			name = "Set OneDrive URLScheme";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ -f ./.integration-test-secrets.sh ]; then\n  source ./.integration-test-secrets.sh\nelse\n  echo \"warning: .integration-test-secrets.sh could not be found, please see README for instructions\"\nfi\n/usr/libexec/PlistBuddy -c \"Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 ${ONEDRIVE_REDIRECT_URI}\" \"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}\"\n";
+		};
 		4ACA641B2616025B00D19304 /* Create IntegrationTestSecrets */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -939,7 +1059,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if [ -f ./.integration-test-secrets.sh ]; then\n  source ./.integration-test-secrets.sh\nelse\n  echo \"warning: .integration-test-secrets.sh could not be found, please see README for instructions\"\nfi\n./create-integration-test-secrets-file.sh\n";
+			shellScript = "./create-integration-test-secrets-file.sh\n";
 		};
 		74862A722469A7AF003D81CB /* Lint With SwiftFormat */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1074,6 +1194,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4A30DB202636E7B6004B5B4E /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A2C631F264181890078EEC6 /* ViewController.swift in Sources */,
+				4A2C6320264181890078EEC6 /* AppDelegate.swift in Sources */,
+				4A2C6321264181890078EEC6 /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4ACA638A2615FDFF00D19304 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1090,20 +1220,24 @@
 				4ACA63E92615FF6400D19304 /* VaultFormat7LocalFileSystemProviderIntegrationTests.swift in Sources */,
 				4ACA63E62615FF6400D19304 /* VaultFormat7GoogleDriveIntegrationTests.swift in Sources */,
 				4ACA63C72615FED700D19304 /* VaultFormat6LocalFileSystemProviderIntegrationTests.swift in Sources */,
+				4A41D2492641960B00B5D787 /* VaultFormat7OneDriveIntegrationTests.swift in Sources */,
 				4ACA64032615FF9800D19304 /* MockDropboxCredential.swift in Sources */,
 				4ACA640D2615FF9800D19304 /* CloudPath+Extension.swift in Sources */,
 				4ACA640A2615FF9800D19304 /* URL+ExtensionsTests.swift in Sources */,
 				4ACA63CC2615FF0000D19304 /* VaultFormat6DropboxIntegrationTests.swift in Sources */,
 				4ACA63A02615FE2C00D19304 /* CloudAccessIntegrationTest.swift in Sources */,
 				4ACA64262616054F00D19304 /* IntegrationTestSecrets.swift in Sources */,
+				4A41D2432641938A00B5D787 /* VaultFormat6OneDriveIntegrationTests.swift in Sources */,
 				4ACA64052615FF9800D19304 /* MockGoogleDriveAuthenticatorTests.swift in Sources */,
 				4ACA63E82615FF6400D19304 /* VaultFormat7DropboxIntegrationTests.swift in Sources */,
 				4ACA63BB2615FEA600D19304 /* DecoratorFactory.swift in Sources */,
+				4AD5530426393EF800126046 /* OneDriveKeychainItem.swift in Sources */,
 				4ACA64042615FF9800D19304 /* MockGoogleDriveAuthenticator.swift in Sources */,
 				4ACA64082615FF9800D19304 /* CloudProvider+IntermediateFolderTests.swift in Sources */,
 				4ACA64092615FF9800D19304 /* CloudPath+ExtensionTests.swift in Sources */,
 				4ACA64022615FF9800D19304 /* DropboxCloudProviderIntegrationTests.swift in Sources */,
 				4ACA63D62615FF2E00D19304 /* VaultFormat6WebDAVIntegrationTests.swift in Sources */,
+				4AFC5F67263190BB00744715 /* OneDriveCloudProviderIntegrationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1115,12 +1249,36 @@
 			target = 4A058FF024519FFC008831F9 /* CryptomatorCloudAccess */;
 			targetProxy = 4A058FFC24519FFC008831F9 /* PBXContainerItemProxy */;
 		};
+		4A30DB412636E7EC004B5B4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4A30DB232636E7B6004B5B4E /* CryptomatorCloudAccessIntegrationTestsHost */;
+			targetProxy = 4A30DB402636E7EC004B5B4E /* PBXContainerItemProxy */;
+		};
 		4ACA63952615FDFF00D19304 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 4A058FF024519FFC008831F9 /* CryptomatorCloudAccess */;
 			targetProxy = 4ACA63942615FDFF00D19304 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		4A2C62E12641554F0078EEC6 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4A2C62E22641554F0078EEC6 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+		4A2C62E32641554F0078EEC6 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4A2C62E42641554F0078EEC6 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
 		4A05900324519FFC008831F9 /* Debug */ = {
@@ -1338,27 +1496,54 @@
 			};
 			name = Release;
 		};
-		4ACA63962615FDFF00D19304 /* Debug */ = {
+		4A30DB362636E7B7004B5B4E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
-				INFOPLIST_FILE = Tests/CryptomatorCloudAccessIntegrationTests/Info.plist;
+				DEVELOPMENT_TEAM = "";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = Tests/CryptomatorCloudAccessIntegrationTestsHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.CloudAccessIntegrationTests;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.CryptomatorCloudAccessIntegrationTestsHost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
-		4ACA63972615FDFF00D19304 /* Release */ = {
+		4A30DB372636E7B7004B5B4E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
+				INFOPLIST_FILE = Tests/CryptomatorCloudAccessIntegrationTestsHost/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.CryptomatorCloudAccessIntegrationTestsHost;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		4ACA63962615FDFF00D19304 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = Tests/CryptomatorCloudAccessIntegrationTests/Info.plist;
@@ -1371,6 +1556,27 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CryptomatorCloudAccessIntegrationTestsHost.app/CryptomatorCloudAccessIntegrationTestsHost";
+			};
+			name = Debug;
+		};
+		4ACA63972615FDFF00D19304 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
+				CODE_SIGN_STYLE = Automatic;
+				INFOPLIST_FILE = Tests/CryptomatorCloudAccessIntegrationTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.CloudAccessIntegrationTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CryptomatorCloudAccessIntegrationTestsHost.app/CryptomatorCloudAccessIntegrationTestsHost";
 			};
 			name = Release;
 		};
@@ -1400,6 +1606,15 @@
 			buildConfigurations = (
 				4A05900924519FFC008831F9 /* Debug */,
 				4A05900A24519FFC008831F9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4A30DB352636E7B7004B5B4E /* Build configuration list for PBXNativeTarget "CryptomatorCloudAccessIntegrationTestsHost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A30DB362636E7B7004B5B4E /* Debug */,
+				4A30DB372636E7B7004B5B4E /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -74,6 +74,42 @@
         }
       },
       {
+        "package": "MSAL",
+        "repositoryURL": "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git",
+        "state": {
+          "branch": null,
+          "revision": "53221d4470b95ecfef92fedb3fd9b105d0c12796",
+          "version": "1.1.16"
+        }
+      },
+      {
+        "package": "MSGraphClientSDK",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc.git",
+        "state": {
+          "branch": "swift-pm",
+          "revision": "a4d0a18ab62176762e4efc2f56021c2f386d98bc",
+          "version": null
+        }
+      },
+      {
+        "package": "MSGraphMSALAuthProvider",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-auth.git",
+        "state": {
+          "branch": "swift-pm",
+          "revision": "2b3c3fd3c3252608b2f8e53a71e1a57a48925690",
+          "version": null
+        }
+      },
+      {
+        "package": "MSGraphClientModels",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-models.git",
+        "state": {
+          "branch": "1.3.0-fixed",
+          "revision": "edd261b525df0e5b56f1a3989210244ed5c18cfe",
+          "version": null
+        }
+      },
+      {
         "package": "Promises",
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {

--- a/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -74,6 +74,15 @@
         }
       },
       {
+        "package": "JOSESwift",
+        "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
+        "state": {
+          "branch": null,
+          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
+          "version": "2.4.0"
+        }
+      },
+      {
         "package": "MSAL",
         "repositoryURL": "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git",
         "state": {
@@ -107,15 +116,6 @@
           "branch": "1.3.0-fixed",
           "revision": "edd261b525df0e5b56f1a3989210244ed5c18cfe",
           "version": null
-        }
-      },
-      {
-        "package": "JOSESwift",
-        "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
-        "state": {
-          "branch": null,
-          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
-          "version": "2.4.0"
         }
       },
       {

--- a/Package.resolved
+++ b/Package.resolved
@@ -74,6 +74,42 @@
         }
       },
       {
+        "package": "MSAL",
+        "repositoryURL": "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git",
+        "state": {
+          "branch": null,
+          "revision": "53221d4470b95ecfef92fedb3fd9b105d0c12796",
+          "version": "1.1.16"
+        }
+      },
+      {
+        "package": "MSGraphClientSDK",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc.git",
+        "state": {
+          "branch": "swift-pm",
+          "revision": "a4d0a18ab62176762e4efc2f56021c2f386d98bc",
+          "version": null
+        }
+      },
+      {
+        "package": "MSGraphMSALAuthProvider",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-auth.git",
+        "state": {
+          "branch": "swift-pm",
+          "revision": "2b3c3fd3c3252608b2f8e53a71e1a57a48925690",
+          "version": null
+        }
+      },
+      {
+        "package": "MSGraphClientModels",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-models.git",
+        "state": {
+          "branch": "1.3.0-fixed",
+          "revision": "edd261b525df0e5b56f1a3989210244ed5c18cfe",
+          "version": null
+        }
+      },
+      {
         "package": "Promises",
         "repositoryURL": "https://github.com/google/promises.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -74,6 +74,15 @@
         }
       },
       {
+        "package": "JOSESwift",
+        "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
+        "state": {
+          "branch": null,
+          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
+          "version": "2.4.0"
+        }
+      },
+      {
         "package": "MSAL",
         "repositoryURL": "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git",
         "state": {
@@ -107,15 +116,6 @@
           "branch": "1.3.0-fixed",
           "revision": "edd261b525df0e5b56f1a3989210244ed5c18cfe",
           "version": null
-        }
-      },
-      {
-        "package": "JOSESwift",
-        "repositoryURL": "https://github.com/airsidemobile/JOSESwift.git",
-        "state": {
-          "branch": null,
-          "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
-          "version": "2.4.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -12,13 +12,14 @@ import PackageDescription
 
 let appExtensionUnsafeSources = [
 	"Dropbox/DropboxAuthenticator.swift",
-	"GoogleDrive/GoogleDriveAuthenticator.swift"
+	"GoogleDrive/GoogleDriveAuthenticator.swift",
+	"OneDrive/OneDriveAuthenticator.swift"
 ]
 
 let package = Package(
 	name: "CryptomatorCloudAccess",
 	platforms: [
-		.iOS(.v10)
+		.iOS(.v11)
 	],
 	products: [
 		.library(name: "CryptomatorCloudAccess", targets: ["CryptomatorCloudAccess"]),
@@ -32,7 +33,10 @@ let package = Package(
 		.package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMinor(from: "4.14.0")),
 		.package(url: "https://github.com/google/GTMAppAuth.git", .upToNextMinor(from: "1.1.0")),
 		.package(url: "https://github.com/google/gtm-session-fetcher.git", .upToNextMinor(from: "1.4.0")),
-		.package(url: "https://github.com/google/promises.git", .upToNextMinor(from: "1.2.0"))
+		.package(url: "https://github.com/google/promises.git", .upToNextMinor(from: "1.2.0")),
+		.package(url: "https://github.com/phil1995/msgraph-sdk-objc-auth.git", .branch("swift-pm")),
+		.package(url: "https://github.com/phil1995/msgraph-sdk-objc-models.git", .branch("1.3.0-fixed")),
+		.package(url: "https://github.com/phil1995/msgraph-sdk-objc.git", .branch("swift-pm"))
 	],
 	targets: [
 		.target(
@@ -44,7 +48,10 @@ let package = Package(
 				"GoogleAPIClientForREST_Drive",
 				"GTMAppAuth",
 				"GTMSessionFetcher",
-				"ObjectiveDropboxOfficial"
+				"ObjectiveDropboxOfficial",
+				"MSGraphClientSDK",
+				"MSGraphClientModels",
+				"MSGraphMSALAuthProvider"
 			],
 			path: "Sources/CryptomatorCloudAccess",
 			exclude: appExtensionUnsafeSources

--- a/Sources/CryptomatorCloudAccess/API/CloudItemType.swift
+++ b/Sources/CryptomatorCloudAccess/API/CloudItemType.swift
@@ -7,8 +7,9 @@
 //
 
 import Foundation
+import GRDB
 
-public enum CloudItemType: String, Codable {
+public enum CloudItemType: String, Codable, DatabaseValueConvertible {
 	case file
 	case folder
 	case symlink

--- a/Sources/CryptomatorCloudAccess/OneDrive/MSGraphDriveItem+CloudItemType.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/MSGraphDriveItem+CloudItemType.swift
@@ -1,0 +1,24 @@
+//
+//  MSGraphDriveItem+CloudItemType.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 29.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import MSGraphClientModels
+extension MSGraphDriveItem {
+	func getCloudItemType() -> CloudItemType {
+		let folder: MSGraphFolder?
+		if let remoteItem = self.remoteItem {
+			folder = remoteItem.folder
+		} else {
+			folder = self.folder
+		}
+		if folder != nil {
+			return .folder
+		} else {
+			return .file
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticationProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticationProvider.swift
@@ -1,0 +1,92 @@
+//
+//  OneDriveAuthenticationProvider.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 23.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import MSAL
+import MSGraphClientSDK
+import Promises
+
+enum OneDriveAuthenticationProviderError: Error {
+	case noAccounts
+	case accountNotFound
+	case invalidAuthProviderOptions
+}
+
+class OneDriveAuthenticationProvider: NSObject, MSAuthenticationProvider {
+	private let identifier: String
+	private let clientApplication: MSALPublicClientApplication
+	private let authProviderOptions: MSAuthenticationProviderOptions
+
+	init(identifier: String, clientApplication: MSALPublicClientApplication, authProviderOptions: MSAuthenticationProviderOptions) {
+		self.identifier = identifier
+		self.clientApplication = clientApplication
+		self.authProviderOptions = authProviderOptions
+	}
+
+	func getAccessToken(for authProviderOptions: MSAuthenticationProviderOptions!, andCompletion completion: ((String?, Error?) -> Void)!) {
+		let scopes: [String]
+		if let authProviderOptions = authProviderOptions {
+			scopes = authProviderOptions.scopesArray
+		} else {
+			scopes = self.authProviderOptions.scopesArray
+		}
+
+		let parameters = MSALAccountEnumerationParameters(identifier: identifier)
+		clientApplication.accountsFromDevice(for: parameters).then { accounts -> Promise<MSALResult> in
+			guard let account = accounts.first else {
+				return Promise(OneDriveAuthenticationProviderError.accountNotFound)
+			}
+			let tokenParameters = MSALSilentTokenParameters(scopes: scopes, account: account)
+			return self.clientApplication.acquireTokenSilent(with: tokenParameters)
+		}.recover { error -> MSALResult in
+			switch error {
+			case let error as NSError where error.domain == MSALErrorDomain && error.code == MSALError.interactionRequired.rawValue:
+				throw CloudProviderError.unauthorized
+			default:
+				throw error
+			}
+		}
+		.then { result in
+			completion(result.accessToken, nil)
+		}.catch { error in
+			completion(nil, error)
+		}
+	}
+}
+
+private extension MSALPublicClientApplication {
+	func accountsFromDevice(for parameters: MSALAccountEnumerationParameters) -> Promise<[MSALAccount]> {
+		return Promise<[MSALAccount]> { fulfill, reject in
+			self.accountsFromDevice(for: parameters) { accounts, error in
+				switch (accounts, error) {
+				case let (.some(accounts), nil):
+					fulfill(accounts)
+				case let (_, .some(error)):
+					reject(error)
+				default:
+					reject(OneDriveAuthenticationProviderError.noAccounts)
+				}
+			}
+		}
+	}
+
+	func acquireTokenSilent(with tokenParameters: MSALSilentTokenParameters) -> Promise<MSALResult> {
+		return Promise<MSALResult> { fulfill, reject in
+			self.acquireTokenSilent(with: tokenParameters) { result, error in
+				switch (result, error) {
+				case let (.some(result), nil):
+					fulfill(result)
+				case let (_, .some(error)):
+					reject(error)
+				default:
+					reject(OneDriveError.unexpectedResult)
+				}
+			}
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticationProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticationProvider.swift
@@ -14,7 +14,6 @@ import Promises
 enum OneDriveAuthenticationProviderError: Error {
 	case noAccounts
 	case accountNotFound
-	case invalidAuthProviderOptions
 }
 
 class OneDriveAuthenticationProvider: NSObject, MSAuthenticationProvider {
@@ -50,8 +49,7 @@ class OneDriveAuthenticationProvider: NSObject, MSAuthenticationProvider {
 			default:
 				throw error
 			}
-		}
-		.then { result in
+		}.then { result in
 			completion(result.accessToken, nil)
 		}.catch { error in
 			completion(nil, error)

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticator.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticator.swift
@@ -1,0 +1,44 @@
+//
+//  OneDriveAuthenticator.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 16.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if canImport(CryptomatorCloudAccessCore)
+import CryptomatorCloudAccessCore
+#endif
+import MSAL
+import Promises
+import UIKit
+
+public enum OneDriveAuthenticatorError: Error {
+	case missingAccountIdentifier
+}
+
+public enum OneDriveAuthenticator {
+	public static func authenticate(from viewController: UIViewController) -> Promise<OneDriveCredential> {
+		let webviewParameters = MSALWebviewParameters(authPresentationViewController: viewController)
+		webviewParameters.webviewType = .safariViewController
+		let interactiveParameters = MSALInteractiveTokenParameters(scopes: OneDriveCredential.scopes, webviewParameters: webviewParameters)
+		return Promise<OneDriveCredential> { fulfill, reject in
+			OneDriveSetup.clientApplication.acquireToken(with: interactiveParameters) { result, error in
+				if let error = error {
+					reject(error)
+					return
+				}
+				guard let result = result, let identifier = result.account.identifier else {
+					reject(OneDriveAuthenticatorError.missingAccountIdentifier)
+					return
+				}
+				do {
+					let credential = try OneDriveCredential(with: identifier)
+					fulfill(credential)
+				} catch {
+					reject(error)
+				}
+			}
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticator.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveAuthenticator.swift
@@ -20,14 +20,12 @@ public enum OneDriveAuthenticatorError: Error {
 public enum OneDriveAuthenticator {
 	public static func authenticate(from viewController: UIViewController) -> Promise<OneDriveCredential> {
 		let webviewParameters = MSALWebviewParameters(authPresentationViewController: viewController)
-		webviewParameters.webviewType = .safariViewController
 		let interactiveParameters = MSALInteractiveTokenParameters(scopes: OneDriveCredential.scopes, webviewParameters: webviewParameters)
 		return OneDriveSetup.clientApplication.acquireToken(with: interactiveParameters).then { result -> OneDriveCredential in
 			guard let identifier = result.account.identifier else {
 				throw OneDriveAuthenticatorError.missingAccountIdentifier
 			}
-			let credential = try OneDriveCredential(with: identifier)
-			return credential
+			return try OneDriveCredential(with: identifier)
 		}
 	}
 }

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -211,7 +211,7 @@ public class OneDriveCloudProvider: CloudProvider {
 
 	func uploadFileChunk(from localURL: URL, offset: Int, totalFileSize: Int, uploadURL: URL, cloudPath: CloudPath) -> Promise<MSGraphDriveItem> {
 		guard let file = FileHandle(forReadingAtPath: localURL.path) else {
-			return Promise(OneDriveError.invalidFilehandle)
+			return Promise(OneDriveError.invalidFileHandle)
 		}
 		file.seek(toFileOffset: UInt64(offset))
 		let data = file.readData(ofLength: OneDriveCloudProvider.uploadFileChunkLength)

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -1,0 +1,623 @@
+//
+//  OneDriveCloudProvider.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 16.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import MSGraphClientModels
+import MSGraphClientSDK
+import Promises
+
+public class OneDriveCloudProvider: CloudProvider {
+	private let credential: OneDriveCredential
+	private let client: MSHTTPClient
+	private let identifierCache: OneDriveIdentifierCache
+	private static let uploadFileChunkLength = 5 * 1024 * 1024 // 5MiB
+
+	public init(credential: OneDriveCredential, useBackgroundSession: Bool = false) throws {
+		self.credential = credential
+		let urlSessionConfiguration = OneDriveCloudProvider.createURLSessionConfiguration(credential: credential, useBackgroundSession: useBackgroundSession)
+		self.client = MSClientFactory.createHTTPClient(with: credential.authProvider, andSessionConfiguration: urlSessionConfiguration)
+		self.identifierCache = try OneDriveIdentifierCache()
+	}
+
+	static func createURLSessionConfiguration(credential: OneDriveCredential, useBackgroundSession: Bool) -> URLSessionConfiguration {
+		let configuration: URLSessionConfiguration
+		if useBackgroundSession {
+			let bundleId = Bundle.main.bundleIdentifier ?? ""
+			configuration = URLSessionConfiguration.background(withIdentifier: "CloudAccess-OneDriveSession-\(credential.identifier)-\(bundleId)")
+			configuration.sharedContainerIdentifier = OneDriveSetup.appGroupName
+		} else {
+			configuration = URLSessionConfiguration.default
+		}
+		return configuration
+	}
+
+	public func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
+		return resolvePath(forItemAt: cloudPath).then(fetchItemMetadata)
+	}
+
+	public func fetchItemList(forFolderAt cloudPath: CloudPath, withPageToken pageToken: String?) -> Promise<CloudItemList> {
+		if let pageToken = pageToken {
+			return fetchItemList(forFolderAt: cloudPath, withPageToken: pageToken)
+		}
+		return resolvePath(forItemAt: cloudPath).then { oneDriveItem in
+			return self.fetchItemList(for: oneDriveItem)
+		}
+	}
+
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+		precondition(localURL.isFileURL)
+		precondition(!localURL.hasDirectoryPath)
+		if FileManager.default.fileExists(atPath: localURL.path) {
+			return Promise(CloudProviderError.itemAlreadyExists)
+		}
+		return resolvePath(forItemAt: cloudPath).then { oneDriveItem in
+			self.downloadFile(oneDriveItem, to: localURL)
+		}
+	}
+
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+		precondition(localURL.isFileURL)
+		precondition(!localURL.hasDirectoryPath)
+		return resolveParentPath(forItemAt: cloudPath).then { _ in
+			self.fetchItemMetadata(at: cloudPath)
+		}.then { metadata -> Void in
+			if replaceExisting {
+				guard metadata.itemType == .file else {
+					throw CloudProviderError.itemTypeMismatch
+				}
+			} else {
+				throw CloudProviderError.itemAlreadyExists
+			}
+		}.recover { error -> Void in
+			guard case CloudProviderError.itemNotFound = error else {
+				throw error
+			}
+		}.then { _ -> Promise<OneDriveItem> in
+			let parentPath = cloudPath.deletingLastPathComponent()
+			return self.resolvePath(forItemAt: parentPath)
+		}.then { oneDriveItem in
+			self.uploadFile(from: localURL, to: oneDriveItem, withFilename: cloudPath.lastPathComponent)
+		}.then { msGraphDriveItem in
+			self.convertMSGraphDriveItemToCloudItemMetadata(msGraphDriveItem, cloudPath: cloudPath)
+		}
+	}
+
+	public func createFolder(at cloudPath: CloudPath) -> Promise<Void> {
+		return checkForItemExistence(at: cloudPath).then { itemExists -> Void in
+			if itemExists {
+				throw CloudProviderError.itemAlreadyExists
+			}
+		}.then {
+			self.resolveParentPath(forItemAt: cloudPath)
+		}.then { parentOneDriveItem in
+			return self.createFolder(withName: cloudPath.lastPathComponent, parentItem: parentOneDriveItem)
+		}
+	}
+
+	public func deleteFile(at cloudPath: CloudPath) -> Promise<Void> {
+		return deleteItem(at: cloudPath, itemType: .file)
+	}
+
+	public func deleteFolder(at cloudPath: CloudPath) -> Promise<Void> {
+		return deleteItem(at: cloudPath, itemType: .folder)
+	}
+
+	public func moveFile(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
+		return moveItem(from: sourceCloudPath, to: targetCloudPath)
+	}
+
+	public func moveFolder(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
+		return moveItem(from: sourceCloudPath, to: targetCloudPath)
+	}
+
+	func fetchItemMetadata(for item: OneDriveItem) -> Promise<CloudItemMetadata> {
+		guard let url = URL(string: requestURLString(for: item)) else {
+			return Promise(OneDriveError.invalidURL)
+		}
+		let request = NSMutableURLRequest(url: url)
+		return executeMSURLSessionDataTaskWithErrorMapping(with: request).then { data -> CloudItemMetadata in
+			let driveItem = try MSGraphDriveItem(data: data)
+			return self.convertMSGraphDriveItemToCloudItemMetadata(driveItem, cloudPath: item.path)
+		}
+	}
+
+	func fetchItemList(for item: OneDriveItem) -> Promise<CloudItemList> {
+		guard item.itemType == .folder else {
+			return Promise(CloudProviderError.itemTypeMismatch)
+		}
+		let request: NSMutableURLRequest
+		do {
+			request = try childrenRequest(for: item)
+		} catch {
+			return Promise(error)
+		}
+		return fetchItemList(forFolderAt: item.path, with: request)
+	}
+
+	func fetchItemList(forFolderAt cloudPath: CloudPath, withPageToken pageToken: String) -> Promise<CloudItemList> {
+		guard let url = URL(string: pageToken) else {
+			return Promise(OneDriveError.invalidURL)
+		}
+		let request = NSMutableURLRequest(url: url)
+		return fetchItemList(forFolderAt: cloudPath, with: request)
+	}
+
+	func fetchItemList(forFolderAt cloudPath: CloudPath, with request: NSMutableURLRequest) -> Promise<CloudItemList> {
+		return executeMSURLSessionDataTaskWithErrorMapping(with: request).then { data -> CloudItemList in
+			let collection = try MSCollection(data: data)
+			return try self.convertMSCollectionToCloudItemList(collection, folderPath: cloudPath)
+		}
+	}
+
+	func downloadFile(_ item: OneDriveItem, to localURL: URL) -> Promise<Void> {
+		guard item.itemType == .file else {
+			return Promise(CloudProviderError.itemTypeMismatch)
+		}
+		let request: NSMutableURLRequest
+		do {
+			request = try contentRequest(for: item)
+		} catch {
+			return Promise(error)
+		}
+		return executeMSURLDownloadTask(with: request, to: localURL)
+	}
+
+	func uploadFile(from localURL: URL, to parentItem: OneDriveItem, withFilename filename: String) -> Promise<MSGraphDriveItem> {
+		let attributes: [FileAttributeKey: Any]
+		do {
+			attributes = try FileManager.default.attributesOfItem(atPath: localURL.path)
+		} catch CocoaError.fileReadNoSuchFile {
+			return Promise(CloudProviderError.itemNotFound)
+		} catch {
+			return Promise(error)
+		}
+		let localItemType = getItemType(from: attributes[FileAttributeKey.type] as? FileAttributeType)
+		guard localItemType == .file else {
+			return Promise(CloudProviderError.itemTypeMismatch)
+		}
+		guard let fileSize = attributes[FileAttributeKey.size] as? Int else {
+			return Promise(OneDriveError.missingFileSize)
+		}
+		return uploadLargeFile(from: localURL, filename: filename, totalFileSize: fileSize, toParentItem: parentItem)
+	}
+
+	func uploadLargeFile(from localURL: URL, filename: String, totalFileSize: Int, toParentItem parentItem: OneDriveItem) -> Promise<MSGraphDriveItem> {
+		let cloudPath = parentItem.path.appendingPathComponent(filename)
+		return createUploadSession(filename: filename, toParentItem: parentItem).then { url in
+			self.uploadFileChunk(from: localURL, offset: 0, totalFileSize: totalFileSize, uploadURL: url, cloudPath: cloudPath)
+		}
+	}
+
+	func createUploadSession(filename: String, toParentItem parentItem: OneDriveItem) -> Promise<URL> {
+		let request: NSMutableURLRequest
+		do {
+			request = try createUploadSessionRequest(forFilename: filename, parentItem: parentItem)
+		} catch {
+			return Promise(error)
+		}
+		return executeMSURLSessionDataTaskWithErrorMapping(with: request).then { data -> URL in
+			let uploadSession = try MSGraphUploadSession(data: data)
+			guard let uploadSessionURLString = uploadSession.uploadUrl, let uploadSessionURL = URL(string: uploadSessionURLString) else {
+				throw OneDriveError.invalidURL
+			}
+			return uploadSessionURL
+		}
+	}
+
+	func uploadFileChunk(from localURL: URL, offset: Int, totalFileSize: Int, uploadURL: URL, cloudPath: CloudPath) -> Promise<MSGraphDriveItem> {
+		guard let file = FileHandle(forReadingAtPath: localURL.path) else {
+			return Promise(OneDriveError.invalidFilehandle)
+		}
+		file.seek(toFileOffset: UInt64(offset))
+		let data = file.readData(ofLength: OneDriveCloudProvider.uploadFileChunkLength)
+		let request = fileCunkUploadRequest(withUploadURL: uploadURL, chunkLength: data.count, offset: Int(offset), totalLength: totalFileSize)
+		return executeMSURLSessionUploadTask(with: request, data: data).then { data, response in
+			switch response.statusCode {
+			case MSExpectedResponseCodes.accepted.rawValue:
+				return self.uploadFileChunk(from: localURL, offset: offset + OneDriveCloudProvider.uploadFileChunkLength, totalFileSize: totalFileSize, uploadURL: uploadURL, cloudPath: cloudPath)
+			case MSExpectedResponseCodes.OK.rawValue, MSExpectedResponseCodes.created.rawValue:
+				let driveItem = try MSGraphDriveItem(data: data)
+				return Promise(driveItem)
+			default:
+				return Promise(self.mapStatusCodeToError(response.statusCode))
+			}
+		}
+	}
+
+	func executeMSURLSessionUploadTask(with request: NSMutableURLRequest, data: Data) -> Promise<(Data, HTTPURLResponse)> {
+		return Promise<(Data, HTTPURLResponse)> { fulfill, reject in
+			let task = MSURLSessionUploadTask(request: request, data: data, client: self.client) { data, response, error in
+				switch (data, response, error) {
+				case let (.some(data), httpResponse as HTTPURLResponse, nil):
+					fulfill((data, httpResponse))
+				case let (_, _, .some(error)):
+					reject(error)
+				default:
+					reject(OneDriveError.unexpectedResult)
+				}
+			}
+			task?.execute()
+		}.recover { error -> (Data, HTTPURLResponse) in
+			throw self.defaultErrorMapping(error)
+		}
+	}
+
+	func fileCunkUploadRequest(withUploadURL uploadURL: URL, chunkLength: Int, offset: Int, totalLength: Int) -> NSMutableURLRequest {
+		let request = NSMutableURLRequest(url: uploadURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 60.0)
+		request.httpMethod = HTTPMethodPut
+		request.setValue(String(chunkLength), forHTTPHeaderField: "Content-Length")
+		request.setValue("bytes \(offset)-\(offset + chunkLength - 1)/\(totalLength)", forHTTPHeaderField: "Content-Range")
+		return request
+	}
+
+	func createFolder(withName name: String, parentItem: OneDriveItem) -> Promise<Void> {
+		let request: NSMutableURLRequest
+		do {
+			request = try createFolderRequest(for: name, in: parentItem)
+		} catch {
+			return Promise(error)
+		}
+		return executeMSURLSessionDataTask(with: request).then { data, response -> Void in
+			guard response.statusCode == MSExpectedResponseCodes.created.rawValue || response.statusCode == MSExpectedResponseCodes.OK.rawValue else {
+				throw self.mapStatusCodeToError(response.statusCode)
+			}
+			let driveItem = try MSGraphDriveItem(data: data)
+			let itemPath = parentItem.path.appendingPathComponent(name)
+			let oneDriveItem = OneDriveItem(path: itemPath, item: driveItem)
+			try self.identifierCache.addOrUpdate(oneDriveItem)
+		}.recover { error -> Void in
+			if case CloudProviderError.itemNotFound = error {
+				try self.identifierCache.remove(parentItem)
+			}
+			throw error
+		}
+	}
+
+	func deleteItem(at cloudPath: CloudPath, itemType: CloudItemType) -> Promise<Void> {
+		let resolvePathPromise = resolvePath(forItemAt: cloudPath)
+		return resolvePathPromise.then(fetchItemMetadata).then { itemMetadata -> Promise<OneDriveItem> in
+			guard itemMetadata.itemType == itemType else {
+				throw CloudProviderError.itemTypeMismatch
+			}
+			return resolvePathPromise
+		}.then { item in
+			return self.deleteItem(item)
+		}.then {
+			resolvePathPromise
+		}.recover { error -> Promise<OneDriveItem> in
+			guard case CloudProviderError.itemNotFound = error else {
+				throw error
+			}
+			return resolvePathPromise
+		}.then { item in
+			try self.identifierCache.remove(item)
+		}
+	}
+
+	func deleteItem(_ item: OneDriveItem) -> Promise<Void> {
+		let request: NSMutableURLRequest
+		do {
+			request = try deleteItemRequest(for: item)
+		} catch {
+			return Promise(error)
+		}
+		return executeMSURLSessionDataTaskWithoutData(with: request).then { response -> Void in
+			guard response.statusCode == 204 else {
+				throw self.mapStatusCodeToError(response.statusCode)
+			}
+		}
+	}
+
+	func moveItem(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
+		return checkForItemExistence(at: targetCloudPath).then { targetItemAlreadyExists in
+			if targetItemAlreadyExists {
+				throw CloudProviderError.itemAlreadyExists
+			}
+		}.then { _ -> Promise<(OneDriveItem, OneDriveItem, OneDriveItem)> in
+			return all(self.resolvePath(forItemAt: sourceCloudPath),
+			           self.resolveParentPath(forItemAt: sourceCloudPath),
+			           self.resolveParentPath(forItemAt: targetCloudPath))
+		}.then { item, currentParentItem, newParentItem in
+			self.moveItem(item, fromParentItem: currentParentItem, toParentItem: newParentItem, to: targetCloudPath)
+		}
+	}
+
+	func moveItem(_ item: OneDriveItem, fromParentItem oldParentItem: OneDriveItem, toParentItem newParentItem: OneDriveItem, to targetCloudPath: CloudPath) -> Promise<Void> {
+		let request: NSMutableURLRequest
+		do {
+			request = try moveItemRequest(for: item, newParentItem: newParentItem, targetCloudPath: targetCloudPath)
+		} catch {
+			return Promise(error)
+		}
+		return executeMSURLSessionDataTaskWithErrorMapping(with: request).then { data -> Void in
+			try self.identifierCache.remove(item)
+			let item = try MSGraphDriveItem(data: data)
+			let oneDriveItem = OneDriveItem(path: targetCloudPath, item: item)
+			try self.identifierCache.addOrUpdate(oneDriveItem)
+		}
+	}
+
+	// MARK: MSURLSessionTask execution
+
+	func executeRawMSURLSessionDataTask(with request: NSMutableURLRequest) -> Promise<(Data?, URLResponse?)> {
+		return Promise<(Data?, URLResponse?)> { fulfill, reject in
+			let task = MSURLSessionDataTask(request: request, client: self.client) { data, response, error in
+				if let error = error {
+					reject(error)
+				} else {
+					fulfill((data, response))
+				}
+			}
+			task?.execute()
+		}.recover { error -> (Data?, URLResponse?) in
+			throw self.defaultErrorMapping(error)
+		}
+	}
+
+	func executeMSURLSessionDataTask(with request: NSMutableURLRequest) -> Promise<(Data, HTTPURLResponse)> {
+		return executeRawMSURLSessionDataTask(with: request).then { data, response -> (Data, HTTPURLResponse) in
+			guard let data = data, let response = response as? HTTPURLResponse else {
+				throw OneDriveError.unexpectedResult
+			}
+			return (data, response)
+		}
+	}
+
+	func executeMSURLSessionDataTaskWithErrorMapping(with request: NSMutableURLRequest) -> Promise<Data> {
+		return executeMSURLSessionDataTask(with: request).then { data, httpResponse -> Data in
+			guard httpResponse.statusCode == MSExpectedResponseCodes.OK.rawValue else {
+				throw (self.mapStatusCodeToError(httpResponse.statusCode))
+			}
+			return data
+		}
+	}
+
+	func executeMSURLSessionDataTaskWithoutData(with request: NSMutableURLRequest) -> Promise<HTTPURLResponse> {
+		return executeRawMSURLSessionDataTask(with: request).then { _, response -> HTTPURLResponse in
+			guard let response = response as? HTTPURLResponse else {
+				throw OneDriveError.unexpectedResult
+			}
+			return response
+		}
+	}
+
+	func executeMSURLDownloadTask(with request: NSMutableURLRequest, to localURL: URL) -> Promise<Void> {
+		return Promise<Void> { fulfill, reject in
+			let task = MSURLSessionDownloadTask(request: request, client: self.client) { tempLocalURL, response, error in
+				switch (tempLocalURL, response, error) {
+				case let (.some(tempLocalURL), httpResponse as HTTPURLResponse, nil):
+					guard httpResponse.statusCode == MSExpectedResponseCodes.OK.rawValue else {
+						reject(self.mapStatusCodeToError(httpResponse.statusCode))
+						return
+					}
+					do {
+						try FileManager.default.moveItem(at: tempLocalURL, to: localURL)
+						fulfill(())
+					} catch {
+						reject(error)
+					}
+				case let (_, _, .some(error)):
+					reject(error)
+				default:
+					reject(OneDriveError.unexpectedResult)
+				}
+			}
+			task?.execute()
+		}.recover { error -> Void in
+			throw self.defaultErrorMapping(error)
+		}
+	}
+
+	// MARK: Resolve Path
+
+	func resolvePath(forItemAt cloudPath: CloudPath) -> Promise<OneDriveItem> {
+		var pathToCheckForCache = cloudPath
+		var cachedOneDriveItem = identifierCache.getCachedItem(for: pathToCheckForCache)
+		while cachedOneDriveItem == nil, !pathToCheckForCache.pathComponents.isEmpty {
+			pathToCheckForCache = pathToCheckForCache.deletingLastPathComponent()
+			cachedOneDriveItem = identifierCache.getCachedItem(for: pathToCheckForCache)
+		}
+		guard let oneDriveItem = cachedOneDriveItem else {
+			return Promise(OneDriveError.inconsistentCache)
+		}
+		if pathToCheckForCache != cloudPath {
+			return traverseThroughPath(from: pathToCheckForCache, to: cloudPath, withStartItem: oneDriveItem)
+		}
+		return Promise(oneDriveItem)
+	}
+
+	func resolveParentPath(forItemAt cloudPath: CloudPath) -> Promise<OneDriveItem> {
+		return resolvePath(forItemAt: cloudPath.deletingLastPathComponent()).recover { error -> OneDriveItem in
+			if case CloudProviderError.itemNotFound = error {
+				throw CloudProviderError.parentFolderDoesNotExist
+			} else {
+				throw error
+			}
+		}
+	}
+
+	func traverseThroughPath(from startCloudPath: CloudPath, to endCloudPath: CloudPath, withStartItem startItem: OneDriveItem) -> Promise<OneDriveItem> {
+		let startIndex = startCloudPath.pathComponents.count
+		let endIndex = endCloudPath.pathComponents.count
+		var parentItem = startItem
+		var currentPath = startCloudPath
+		return Promise(on: .global()) { fulfill, _ in
+			for i in startIndex ..< endIndex {
+				let itemName = endCloudPath.pathComponents[i]
+				currentPath = currentPath.appendingPathComponent(itemName)
+				parentItem = try await(self.getOneDriveItem(for: itemName, withParentItem: parentItem))
+				try self.identifierCache.addOrUpdate(parentItem)
+			}
+			fulfill(parentItem)
+		}
+	}
+
+	func getOneDriveItem(for name: String, withParentItem parentItem: OneDriveItem) -> Promise<OneDriveItem> {
+		guard let encodedName = name.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed), let url = URL(string: "\(requestURLString(for: parentItem)):/\(encodedName)") else {
+			return Promise(OneDriveError.invalidURL)
+		}
+		let request = NSMutableURLRequest(url: url)
+		return executeMSURLSessionDataTaskWithErrorMapping(with: request).then { data -> OneDriveItem in
+			let item = try MSGraphDriveItem(data: data)
+			let oneDriveItem = OneDriveItem(path: parentItem.path.appendingPathComponent(name), item: item)
+			return oneDriveItem
+		}
+	}
+
+	// MARK: Requests
+
+	func requestURLString(for item: OneDriveItem) -> String {
+		if let driveIdentifier = item.driveIdentifier {
+			return "\(MSGraphBaseURL)/drives/\(driveIdentifier)/items/\(item.itemIdentifier)"
+		} else {
+			return "\(MSGraphBaseURL)/me/drive/items/\(item.itemIdentifier)"
+		}
+	}
+
+	func childrenRequest(for item: OneDriveItem) throws -> NSMutableURLRequest {
+		guard let url = URL(string: "\(requestURLString(for: item))/children") else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		return request
+	}
+
+	func contentRequest(for item: OneDriveItem) throws -> NSMutableURLRequest {
+		guard let url = URL(string: "\(requestURLString(for: item))/content") else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		return request
+	}
+
+	func createUploadSessionRequest(forFilename filename: String, parentItem: OneDriveItem) throws -> NSMutableURLRequest {
+		guard let encodedName = filename.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed), let url = URL(string: "\(requestURLString(for: parentItem)):/\(encodedName):/createUploadSession") else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		request.httpMethod = HTTPMethodPost
+		return request
+	}
+
+	func createFolderRequest(for foldername: String, in parentItem: OneDriveItem) throws -> NSMutableURLRequest {
+		guard let url = URL(string: "\(requestURLString(for: parentItem))/children") else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.httpMethod = HTTPMethodPost
+		let newFolder = MSGraphDriveItem()
+		newFolder.name = foldername
+		newFolder.folder = MSGraphFolder()
+		let newFolderData = try newFolder.getSerializedData()
+		request.httpBody = newFolderData
+		return request
+	}
+
+	func deleteItemRequest(for item: OneDriveItem) throws -> NSMutableURLRequest {
+		guard let url = URL(string: requestURLString(for: item)) else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		request.httpMethod = HTTPMethodDelete
+		return request
+	}
+
+	func moveItemRequest(for item: OneDriveItem, newParentItem: OneDriveItem, targetCloudPath: CloudPath) throws -> NSMutableURLRequest {
+		guard let url = URL(string: requestURLString(for: item)) else {
+			throw OneDriveError.invalidURL
+		}
+		let request = NSMutableURLRequest(url: url)
+		request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+		request.httpMethod = HTTPMethodPatch
+		let updatedItem = MSGraphDriveItem()
+		updatedItem.name = targetCloudPath.lastPathComponent
+		let parentReference = MSGraphItemReference()
+		parentReference.itemReferenceId = newParentItem.itemIdentifier
+		parentReference.driveId = newParentItem.driveIdentifier
+		updatedItem.parentReference = parentReference
+		let updatedItemData: Data
+		updatedItemData = try updatedItem.getSerializedData()
+		request.httpBody = updatedItemData
+		return request
+	}
+
+	// MARK: Helper
+
+	func convertMSCollectionToCloudItemList(_ collection: MSCollection, folderPath: CloudPath) throws -> CloudItemList {
+		var items = [CloudItemMetadata]()
+		for case let item as [AnyHashable: Any] in collection.value {
+			guard let driveItem = MSGraphDriveItem(dictionary: item) else {
+				throw OneDriveError.unexpectedResult
+			}
+			guard let name = driveItem.name else {
+				throw OneDriveError.missingItemName
+			}
+			let itemPath = folderPath.appendingPathComponent(name)
+			let itemMetdata = convertMSGraphDriveItemToCloudItemMetadata(driveItem, cloudPath: itemPath)
+			let oneDriveItem = OneDriveItem(path: itemPath, item: driveItem)
+			try identifierCache.addOrUpdate(oneDriveItem)
+			items.append(itemMetdata)
+		}
+		if collection.nextLink == nil {
+			return CloudItemList(items: items, nextPageToken: nil)
+		}
+		return CloudItemList(items: items, nextPageToken: collection.nextLink.absoluteString)
+	}
+
+	func convertMSGraphDriveItemToCloudItemMetadata(_ driveItem: MSGraphDriveItem, cloudPath: CloudPath) -> CloudItemMetadata {
+		let lastModifiedDate = driveItem.fileSystemInfo?.lastModifiedDateTime
+		let itemSize = Int(exactly: driveItem.size)
+		let name: String
+		if let driveItemName = driveItem.name {
+			name = driveItemName
+		} else {
+			name = cloudPath.lastPathComponent
+		}
+		let itemMetadata = CloudItemMetadata(name: name, cloudPath: cloudPath, itemType: driveItem.getCloudItemType(), lastModifiedDate: lastModifiedDate, size: itemSize)
+		return itemMetadata
+	}
+
+	func mapStatusCodeToError(_ statusCode: Int) -> Error {
+		switch statusCode {
+		case MSClientErrorCode.MSClientErrorCodeNotFound.rawValue:
+			return CloudProviderError.itemNotFound
+		case MSClientErrorCode.MSClientErrorCodeInsufficientStorage.rawValue:
+			return CloudProviderError.quotaInsufficient
+		case MSClientErrorCode.MSClientErrorCodeUnauthorized.rawValue:
+			return CloudProviderError.unauthorized
+		case MSClientErrorCode.MSClientErrorCodeInsufficientStorage.rawValue:
+			return CloudProviderError.quotaInsufficient
+		default:
+			return OneDriveError.unexpectedHTTPStatusCode(code: statusCode)
+		}
+	}
+
+	func getItemType(from fileAttributeType: FileAttributeType?) -> CloudItemType {
+		guard let type = fileAttributeType else {
+			return CloudItemType.unknown
+		}
+		switch type {
+		case .typeDirectory:
+			return CloudItemType.folder
+		case .typeRegular:
+			return CloudItemType.file
+		default:
+			return CloudItemType.unknown
+		}
+	}
+
+	func defaultErrorMapping(_ error: Error) -> Error {
+		switch error {
+		case OneDriveAuthenticationProviderError.accountNotFound, OneDriveAuthenticationProviderError.noAccounts:
+			return CloudProviderError.unauthorized
+		default:
+			return error
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCredential.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCredential.swift
@@ -1,0 +1,47 @@
+//
+//  OneDriveCredential.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 16.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import MSGraphMSALAuthProvider
+import Promises
+public enum OneDriveCredentialError: Error {
+	case noUsername
+}
+
+public class OneDriveCredential {
+	public static let scopes = ["https://graph.microsoft.com/Files.ReadWrite"]
+	private static let authProviderOptions: MSAuthenticationProviderOptions = MSALAuthenticationProviderOptions(scopes: scopes)
+
+	public let identifier: String
+	let authProvider: MSAuthenticationProvider
+	private let clientApplication: MSALPublicClientApplication
+
+	public convenience init(with identifier: String) throws {
+		let authProvider = OneDriveAuthenticationProvider(identifier: identifier, clientApplication: OneDriveSetup.clientApplication, authProviderOptions: OneDriveCredential.authProviderOptions)
+		try self.init(with: identifier, authProvider: authProvider, clientApplication: OneDriveSetup.clientApplication)
+	}
+
+	init(with identifier: String, authProvider: MSAuthenticationProvider, clientApplication: MSALPublicClientApplication) throws {
+		self.identifier = identifier
+		self.authProvider = authProvider
+		self.clientApplication = clientApplication
+	}
+
+	public func getUsername() throws -> String {
+		let account = try clientApplication.account(forIdentifier: identifier)
+		guard let username = account.username else {
+			throw OneDriveCredentialError.noUsername
+		}
+		return username
+	}
+
+	public func deauthenticate() throws {
+		let account = try clientApplication.account(forIdentifier: identifier)
+		try clientApplication.remove(account)
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveError.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveError.swift
@@ -14,6 +14,6 @@ public enum OneDriveError: Error {
 	case inconsistentCache
 	case missingItemName
 	case unexpectedHTTPStatusCode(code: Int)
-	case invalidFilehandle
+	case invalidFileHandle
 	case missingFileSize
 }

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveError.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveError.swift
@@ -1,0 +1,19 @@
+//
+//  OneDriveError.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 17.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+
+public enum OneDriveError: Error {
+	case invalidURL
+	case unexpectedResult
+	case inconsistentCache
+	case missingItemName
+	case unexpectedHTTPStatusCode(code: Int)
+	case invalidFilehandle
+	case missingFileSize
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveIdentifierCache.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveIdentifierCache.swift
@@ -1,0 +1,46 @@
+//
+//  OneDriveIdentifierCache.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 20.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import GRDB
+class OneDriveIdentifierCache {
+	private let inMemoryDB: DatabaseQueue
+
+	init() throws {
+		self.inMemoryDB = DatabaseQueue()
+		try inMemoryDB.write { db in
+			try db.create(table: OneDriveItem.databaseTableName) { table in
+				table.column(OneDriveItem.pathKey, .text).primaryKey()
+				table.column(OneDriveItem.identifierKey, .text).notNull()
+				table.column(OneDriveItem.driveIdentifierKey, .text)
+				table.column(OneDriveItem.itemTypeKey, .text).notNull()
+			}
+		}
+		let rootItem = OneDriveItem(path: CloudPath("/"), itemIdentifier: "root", driveIdentifier: nil, itemType: .folder)
+		try addOrUpdate(rootItem)
+	}
+
+	func addOrUpdate(_ item: OneDriveItem) throws {
+		try inMemoryDB.write { db in
+			try item.save(db)
+		}
+	}
+
+	func getCachedItem(for cloudPath: CloudPath) -> OneDriveItem? {
+		try? inMemoryDB.read { db in
+			let cachedItem = try OneDriveItem.fetchOne(db, key: [OneDriveItem.pathKey: cloudPath])
+			return cachedItem
+		}
+	}
+
+	func remove(_ item: OneDriveItem) throws {
+		try inMemoryDB.write { db in
+			try item.delete(db)
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveItem.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveItem.swift
@@ -1,0 +1,51 @@
+//
+//  OneDriveItem.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 19.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import GRDB
+import MSGraphClientModels
+
+struct OneDriveItem: Decodable, FetchableRecord, TableRecord {
+	let itemIdentifier: String
+	let driveIdentifier: String?
+	let path: CloudPath
+	let itemType: CloudItemType
+
+	static let databaseTableName = "cachedEntries"
+	static let pathKey = "path"
+	static let identifierKey = "itemIdentifier"
+	static let driveIdentifierKey = "driveIdentifier"
+	static let itemTypeKey = "itemType"
+
+	init(path: CloudPath, itemIdentifier: String, driveIdentifier: String?, itemType: CloudItemType) {
+		self.path = path
+		self.itemIdentifier = itemIdentifier
+		self.driveIdentifier = driveIdentifier
+		self.itemType = itemType
+	}
+
+	init(path: CloudPath, item: MSGraphDriveItem) {
+		self.path = path
+		self.itemIdentifier = item.remoteItem?.remoteItemId ?? item.entityId
+		if let remoteDriveId = item.remoteItem?.parentReference?.driveId {
+			self.driveIdentifier = remoteDriveId
+		} else {
+			self.driveIdentifier = item.parentReference?.driveId
+		}
+		self.itemType = item.getCloudItemType()
+	}
+}
+
+extension OneDriveItem: PersistableRecord {
+	func encode(to container: inout PersistenceContainer) {
+		container[OneDriveItem.pathKey] = path
+		container[OneDriveItem.identifierKey] = itemIdentifier
+		container[OneDriveItem.driveIdentifierKey] = driveIdentifier
+		container[OneDriveItem.itemTypeKey] = itemType
+	}
+}

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveSetup.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveSetup.swift
@@ -1,0 +1,14 @@
+//
+//  OneDriveSetup.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 16.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import MSAL
+public enum OneDriveSetup {
+	public static var clientApplication: MSALPublicClientApplication!
+	public static var appGroupName: String!
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6OneDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6OneDriveIntegrationTests.swift
@@ -1,0 +1,101 @@
+//
+//  VaultFormat6OneDriveIntegrationTests.swift
+//  CryptomatorCloudAccessIntegrationTests
+//
+//  Created by Philipp Schmid on 04.05.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if canImport(CryptomatorCloudAccessCore)
+import CryptomatorCloudAccessCore
+#else
+import CryptomatorCloudAccess
+#endif
+import Foundation
+import XCTest
+@testable import MSAL
+@testable import Promises
+class VaultFormat6OneDriveIntegrationTests: CloudAccessIntegrationTest {
+	static var setUpErrorForVaultFormat6OneDrive: Error?
+
+	override class var classSetUpError: Error? {
+		get {
+			return setUpErrorForVaultFormat6OneDrive
+		}
+		set {
+			setUpErrorForVaultFormat6OneDrive = newValue
+		}
+	}
+
+	private static let cloudProvider = createSetUpOneDriveCloudProvider()
+	private static let vaultPath = CloudPath("/IntegrationTests-Vault6/")
+
+	static var setUpProviderForVaultFormat6OneDrive: VaultFormat6ProviderDecorator?
+
+	class func createSetUpOneDriveCloudProvider() -> OneDriveCloudProvider {
+		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: IntegrationTestSecrets.oneDriveClientId, redirectUri: IntegrationTestSecrets.oneDriveRedirectUri, authority: nil)
+		oneDriveConfiguration.cacheConfig.keychainSharingGroup = Bundle.main.bundleIdentifier ?? ""
+		let credential: OneDriveCredential
+		let cloudProvider: OneDriveCloudProvider
+		do {
+			OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			let keychainItem = try OneDriveKeychainItem.getOneDriveAccountKeychainItem()
+			let accountId = keychainItem.homeAccountId
+			credential = try OneDriveCredential(with: accountId)
+			cloudProvider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		} catch {
+			fatalError("Creation of setUp OneDriveCloudProvider failed with: \(error)")
+		}
+		return cloudProvider
+	}
+
+	override class var setUpProvider: CloudProvider? {
+		return setUpProviderForVaultFormat6OneDrive
+	}
+
+	override class var integrationTestParentCloudPath: CloudPath {
+		return CloudPath("/")
+	}
+
+	override class func setUp() {
+		do {
+			try OneDriveKeychainItem.fillKeychain()
+		} catch {
+			classSetUpError = error
+			return
+		}
+		let setUpPromise = cloudProvider.deleteFolderIfExisting(at: vaultPath).then {
+			DecoratorFactory.createNewVaultFormat6(delegate: cloudProvider, vaultPath: vaultPath, password: "IntegrationTest")
+		}.then { decorator in
+			setUpProviderForVaultFormat6OneDrive = decorator
+		}.catch { error in
+			print("VaultFormat6OneDriveIntegrationTests setup error: \(error)")
+		}
+		guard waitForPromises(timeout: 60.0) else {
+			classSetUpError = IntegrationTestError.oneTimeSetUpTimeout
+			return
+		}
+		if let error = setUpPromise.error {
+			classSetUpError = error
+			return
+		}
+		super.setUp()
+	}
+
+	override func setUpWithError() throws {
+		let expectation = XCTestExpectation()
+		try super.setUpWithError()
+		DecoratorFactory.createFromExistingVaultFormat6(delegate: VaultFormat6OneDriveIntegrationTests.cloudProvider, vaultPath: VaultFormat6OneDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
+			super.provider = decorator
+		}.catch { error in
+			XCTFail("Promise failed with error: \(error)")
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 60.0)
+	}
+
+	override class var defaultTestSuite: XCTestSuite {
+		return XCTestSuite(forTestCaseClass: VaultFormat6OneDriveIntegrationTests.self)
+	}
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7OneDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7OneDriveIntegrationTests.swift
@@ -1,0 +1,101 @@
+//
+//  VaultFormat7OneDriveIntegrationTests.swift
+//  CryptomatorCloudAccessIntegrationTests
+//
+//  Created by Philipp Schmid on 04.05.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if canImport(CryptomatorCloudAccessCore)
+import CryptomatorCloudAccessCore
+#else
+import CryptomatorCloudAccess
+#endif
+import Foundation
+import XCTest
+@testable import MSAL
+@testable import Promises
+class VaultFormat7OneDriveIntegrationTests: CloudAccessIntegrationTest {
+	static var setUpErrorForVaultFormat7OneDrive: Error?
+
+	override class var classSetUpError: Error? {
+		get {
+			return setUpErrorForVaultFormat7OneDrive
+		}
+		set {
+			setUpErrorForVaultFormat7OneDrive = newValue
+		}
+	}
+
+	private static let cloudProvider = createSetUpOneDriveCloudProvider()
+	private static let vaultPath = CloudPath("/IntegrationTests-Vault7/")
+
+	static var setUpProviderForVaultFormat7OneDrive: VaultFormat7ProviderDecorator?
+
+	class func createSetUpOneDriveCloudProvider() -> OneDriveCloudProvider {
+		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: IntegrationTestSecrets.oneDriveClientId, redirectUri: IntegrationTestSecrets.oneDriveRedirectUri, authority: nil)
+		oneDriveConfiguration.cacheConfig.keychainSharingGroup = Bundle.main.bundleIdentifier ?? ""
+		let credential: OneDriveCredential
+		let cloudProvider: OneDriveCloudProvider
+		do {
+			OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			let keychainItem = try OneDriveKeychainItem.getOneDriveAccountKeychainItem()
+			let accountId = keychainItem.homeAccountId
+			credential = try OneDriveCredential(with: accountId)
+			cloudProvider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		} catch {
+			fatalError("Creation of setUp OneDriveCloudProvider failed with: \(error)")
+		}
+		return cloudProvider
+	}
+
+	override class var setUpProvider: CloudProvider? {
+		return setUpProviderForVaultFormat7OneDrive
+	}
+
+	override class var integrationTestParentCloudPath: CloudPath {
+		return CloudPath("/")
+	}
+
+	override class func setUp() {
+		do {
+			try OneDriveKeychainItem.fillKeychain()
+		} catch {
+			classSetUpError = error
+			return
+		}
+		let setUpPromise = cloudProvider.deleteFolderIfExisting(at: vaultPath).then {
+			DecoratorFactory.createNewVaultFormat7(delegate: cloudProvider, vaultPath: vaultPath, password: "IntegrationTest")
+		}.then { decorator in
+			setUpProviderForVaultFormat7OneDrive = decorator
+		}.catch { error in
+			print("VaultFormat7OneDriveIntegrationTests setup error: \(error)")
+		}
+		guard waitForPromises(timeout: 60.0) else {
+			classSetUpError = IntegrationTestError.oneTimeSetUpTimeout
+			return
+		}
+		if let error = setUpPromise.error {
+			classSetUpError = error
+			return
+		}
+		super.setUp()
+	}
+
+	override func setUpWithError() throws {
+		let expectation = XCTestExpectation()
+		try super.setUpWithError()
+		DecoratorFactory.createFromExistingVaultFormat7(delegate: VaultFormat7OneDriveIntegrationTests.cloudProvider, vaultPath: VaultFormat7OneDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
+			super.provider = decorator
+		}.catch { error in
+			XCTFail("Promise failed with error: \(error)")
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 60.0)
+	}
+
+	override class var defaultTestSuite: XCTestSuite {
+		return XCTestSuite(forTestCaseClass: VaultFormat7OneDriveIntegrationTests.self)
+	}
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveCloudProviderIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveCloudProviderIntegrationTests.swift
@@ -1,0 +1,86 @@
+//
+//  OneDriveCloudProviderIntegrationTests.swift
+//  CryptomatorCloudAccessIntegrationTests
+//
+//  Created by Philipp Schmid on 22.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccess
+import Foundation
+import Promises
+import XCTest
+@testable import MSAL
+class OneDriveCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAuthentication {
+	static var setUpErrorForOneDrive: Error?
+	override class var classSetUpError: Error? {
+		get {
+			return setUpErrorForOneDrive
+		}
+		set {
+			setUpErrorForOneDrive = newValue
+		}
+	}
+
+	static let setUpProviderForOneDrive = createSetUpOneDriveCloudProvider()
+
+	override class var setUpProvider: CloudProvider {
+		return setUpProviderForOneDrive
+	}
+
+	class func createSetUpOneDriveCloudProvider() -> OneDriveCloudProvider {
+		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: IntegrationTestSecrets.oneDriveClientId, redirectUri: IntegrationTestSecrets.oneDriveRedirectUri, authority: nil)
+		oneDriveConfiguration.cacheConfig.keychainSharingGroup = Bundle.main.bundleIdentifier ?? ""
+		let credential: OneDriveCredential
+		let cloudProvider: OneDriveCloudProvider
+		do {
+			OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			let keychainItem = try OneDriveKeychainItem.getOneDriveAccountKeychainItem()
+			let accountId = keychainItem.homeAccountId
+			credential = try OneDriveCredential(with: accountId)
+			cloudProvider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		} catch {
+			fatalError("Creation of setUp OneDriveCloudProvider failed with: \(error)")
+		}
+		return cloudProvider
+	}
+
+	override class var integrationTestParentCloudPath: CloudPath {
+		return CloudPath("/iOS-IntegrationTest/plain/")
+	}
+
+	override class func setUp() {
+		do {
+			try OneDriveKeychainItem.fillKeychain()
+		} catch {
+			classSetUpError = error
+			return
+		}
+		super.setUp()
+	}
+
+	private var credential: OneDriveCredential!
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		let keychainItem = try OneDriveKeychainItem.getOneDriveAccountKeychainItem()
+		let accountId = keychainItem.homeAccountId
+		let credential = try OneDriveCredential(with: accountId)
+		self.credential = credential
+		super.provider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	}
+
+	override class var defaultTestSuite: XCTestSuite {
+		return XCTestSuite(forTestCaseClass: OneDriveCloudProviderIntegrationTests.self)
+	}
+
+	override func deauthenticate() -> Promise<Void> {
+		do {
+			credential = try OneDriveCredential(with: "InvalidIdentifier")
+			super.provider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		} catch {
+			return Promise(error)
+		}
+		return Promise(())
+	}
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveKeychainItem.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveKeychainItem.swift
@@ -27,7 +27,7 @@ extension OneDriveKeychainItem {
 	static func fillKeychain() throws {
 		let refreshTokenItem = try getOneDriveRefreshTokenKeychainItem()
 		let accountAttribute = "\(refreshTokenItem.homeAccountId)-\(refreshTokenItem.environment)"
-		let oneDriveKeychainRefreshTokenItem = OneDriveKeychainItem(account: accountAttribute, data: IntegrationTestSecrets.oneDriveRefrehTokenData, service: "refreshtoken-\(refreshTokenItem.clientId)--", secClass: kSecClassGenericPassword as String, generic: "refreshtoken-\(refreshTokenItem.clientId)-".data(using: .utf8), type: 2002 as CFNumber, accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
+		let oneDriveKeychainRefreshTokenItem = OneDriveKeychainItem(account: accountAttribute, data: IntegrationTestSecrets.oneDriveRefreshTokenData, service: "refreshtoken-\(refreshTokenItem.clientId)--", secClass: kSecClassGenericPassword as String, generic: "refreshtoken-\(refreshTokenItem.clientId)-".data(using: .utf8), type: 2002 as CFNumber, accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
 		try save(oneDriveKeychainRefreshTokenItem)
 
 		let accountItem = try getOneDriveAccountKeychainItem()
@@ -38,7 +38,7 @@ extension OneDriveKeychainItem {
 	static func getOneDriveRefreshTokenKeychainItem() throws -> OneDriveRefreshTokenKeychain {
 		let decoder = JSONDecoder()
 		decoder.keyDecodingStrategy = .convertFromSnakeCase
-		guard let data = IntegrationTestSecrets.oneDriveRefrehTokenData else {
+		guard let data = IntegrationTestSecrets.oneDriveRefreshTokenData else {
 			throw OneDriveKeychainItemError.missingAccountData
 		}
 		return try decoder.decode(OneDriveRefreshTokenKeychain.self, from: data)

--- a/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveKeychainItem.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveKeychainItem.swift
@@ -1,0 +1,95 @@
+//
+//  OneDriveKeychainItems.swift
+//  CryptomatorCloudAccessIntegrationTests
+//
+//  Created by Philipp Schmid on 28.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+
+enum OneDriveKeychainItemError: Error {
+	case unhandledKeychainError(status: OSStatus)
+	case missingAccountData
+}
+
+struct OneDriveKeychainItem {
+	let account: String
+	let data: Data?
+	let service: String
+	let secClass: String
+	let generic: Data?
+	let type: CFNumber?
+	let accessible: String
+}
+
+extension OneDriveKeychainItem {
+	static func fillKeychain() throws {
+		let refreshTokenItem = try getOneDriveRefreshTokenKeychainItem()
+		let accountAttribute = "\(refreshTokenItem.homeAccountId)-\(refreshTokenItem.environment)"
+		let oneDriveKeychainRefreshTokenItem = OneDriveKeychainItem(account: accountAttribute, data: IntegrationTestSecrets.oneDriveRefrehTokenData, service: "refreshtoken-\(refreshTokenItem.clientId)--", secClass: kSecClassGenericPassword as String, generic: "refreshtoken-\(refreshTokenItem.clientId)-".data(using: .utf8), type: 2002 as CFNumber, accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
+		try save(oneDriveKeychainRefreshTokenItem)
+
+		let accountItem = try getOneDriveAccountKeychainItem()
+		let oneDriveKeychainAccountItem = OneDriveKeychainItem(account: accountAttribute, data: IntegrationTestSecrets.oneDriveAccountData, service: accountItem.realm, secClass: kSecClassGenericPassword as String, generic: nil, type: 1003 as CFNumber, accessible: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
+		try save(oneDriveKeychainAccountItem)
+	}
+
+	static func getOneDriveRefreshTokenKeychainItem() throws -> OneDriveRefreshTokenKeychain {
+		let decoder = JSONDecoder()
+		decoder.keyDecodingStrategy = .convertFromSnakeCase
+		guard let data = IntegrationTestSecrets.oneDriveRefrehTokenData else {
+			throw OneDriveKeychainItemError.missingAccountData
+		}
+		return try decoder.decode(OneDriveRefreshTokenKeychain.self, from: data)
+	}
+
+	static func getOneDriveAccountKeychainItem() throws -> OneDriveAccountKeychain {
+		let decoder = JSONDecoder()
+		decoder.keyDecodingStrategy = .convertFromSnakeCase
+		guard let data = IntegrationTestSecrets.oneDriveAccountData else {
+			throw OneDriveKeychainItemError.missingAccountData
+		}
+		return try decoder.decode(OneDriveAccountKeychain.self, from: data)
+	}
+
+	static func save(_ item: OneDriveKeychainItem) throws {
+		var query = [
+			kSecAttrAccount as String: item.account as AnyObject,
+			kSecAttrService as String: item.service as AnyObject,
+			kSecClass as String: item.secClass as AnyObject,
+			kSecAttrAccessible as String: item.accessible as AnyObject
+		]
+		query[kSecValueData as String] = item.data as AnyObject?
+		query[kSecAttrGeneric as String] = item.generic as AnyObject?
+		query[kSecAttrType as String] = item.type as AnyObject?
+
+		let keychainQuery = query as CFDictionary
+
+		SecItemDelete(keychainQuery)
+		let status = SecItemAdd(keychainQuery, nil)
+
+		guard status == noErr else {
+			throw OneDriveKeychainItemError.unhandledKeychainError(status: status)
+		}
+	}
+}
+
+struct OneDriveRefreshTokenKeychain: Codable {
+	let clientId: String
+	let secret: String
+	let environment: String
+	let credentialType: String
+	let homeAccountId: String
+}
+
+struct OneDriveAccountKeychain: Codable {
+	let clientInfo: String
+	let localAccountId: String
+	let homeAccountId: String
+	let username: String
+	let environment: String
+	let realm: String
+	let authorityType: String
+	let name: String
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/AppDelegate.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/AppDelegate.swift
@@ -1,0 +1,31 @@
+//
+//  AppDelegate.swift
+//  CryptomatorCloudAccessIntegrationTestsHost
+//
+//  Created by Philipp Schmid on 26.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+	func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+		// Override point for customization after application launch.
+		return true
+	}
+
+	// MARK: UISceneSession Lifecycle
+
+	func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+		// Called when a new scene session is being created.
+		// Use this method to select a configuration to create the new scene with.
+		return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+	}
+
+	func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+		// Called when the user discards a scene session.
+		// If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+		// Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+	}
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "2x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "iphone",
+      "scale" : "3x",
+      "size" : "60x60"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "20x20"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "29x29"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "40x40"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "1x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "76x76"
+    },
+    {
+      "idiom" : "ipad",
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/Contents.json
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Base.lproj/LaunchScreen.storyboard
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Base.lproj/Main.storyboard
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/Info.plist
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/Info.plist
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>None</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>ONEDRIVE_URL_SCHEME</string>
+			</array>
+		</dict>
+	</array>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/SceneDelegate.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/SceneDelegate.swift
@@ -1,0 +1,47 @@
+//
+//  SceneDelegate.swift
+//  CryptomatorCloudAccessIntegrationTestsHost
+//
+//  Created by Philipp Schmid on 26.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+	var window: UIWindow?
+
+	func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+		// Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+		// If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+		// This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+	}
+
+	func sceneDidDisconnect(_ scene: UIScene) {
+		// Called as the scene is being released by the system.
+		// This occurs shortly after the scene enters the background, or when its session is discarded.
+		// Release any resources associated with this scene that can be re-created the next time the scene connects.
+		// The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+	}
+
+	func sceneDidBecomeActive(_ scene: UIScene) {
+		// Called when the scene has moved from an inactive state to an active state.
+		// Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+	}
+
+	func sceneWillResignActive(_ scene: UIScene) {
+		// Called when the scene will move from an active state to an inactive state.
+		// This may occur due to temporary interruptions (ex. an incoming phone call).
+	}
+
+	func sceneWillEnterForeground(_ scene: UIScene) {
+		// Called as the scene transitions from the background to the foreground.
+		// Use this method to undo the changes made on entering the background.
+	}
+
+	func sceneDidEnterBackground(_ scene: UIScene) {
+		// Called as the scene transitions from the foreground to the background.
+		// Use this method to save data, release shared resources, and store enough scene-specific state information
+		// to restore the scene back to its current state.
+	}
+}

--- a/Tests/CryptomatorCloudAccessIntegrationTestsHost/ViewController.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTestsHost/ViewController.swift
@@ -1,0 +1,16 @@
+//
+//  ViewController.swift
+//  CryptomatorCloudAccessIntegrationTestsHost
+//
+//  Created by Philipp Schmid on 26.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		// Do any additional setup after loading the view.
+	}
+}

--- a/Tests/CryptomatorCloudAccessTests/Crypto/DirectoryIdCacheTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/DirectoryIdCacheTests.swift
@@ -60,7 +60,7 @@ class DirectoryIdCacheTests: XCTestCase {
 		let path = CloudPath("/one/two/three")
 
 		var misses: [String] = []
-		let result = cache.get(path, onMiss: { (cleartextPath, parentDirId) -> Promise<Data> in
+		let result = cache.get(path, onMiss: { cleartextPath, parentDirId -> Promise<Data> in
 			let dirId: String = {
 				switch cleartextPath.lastPathComponent {
 				case "one":

--- a/Tests/CryptomatorCloudAccessTests/OneDrive/OneDriveCloudProviderTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/OneDrive/OneDriveCloudProviderTests.swift
@@ -1,0 +1,106 @@
+//
+//  OneDriveCloudProviderTests.swift
+//  CryptomatorCloudAccessIntegrationTests
+//
+//  Created by Philipp Schmid on 26.04.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import MSAL
+import MSGraphMSALAuthProvider
+import XCTest
+#if canImport(CryptomatorCloudAccessCore)
+@testable import CryptomatorCloudAccessCore
+#else
+@testable import CryptomatorCloudAccess
+#endif
+
+class OneDriveCloudProviderTests: XCTestCase {
+	var provider: OneDriveCloudProvider!
+
+	override func setUpWithError() throws {
+		let credential = try OneDriveCredential(with: "Test", authProvider: MSAuthenticationProviderMock(), clientApplication: MSALPublicClientApplication())
+		provider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	}
+
+	func testFileCunkUploadRequest() throws {
+		let uploadURL = URL(string: "example.com")!
+		let chunkLength = 26
+		let totalLength = 128
+		let request = provider.fileCunkUploadRequest(withUploadURL: uploadURL, chunkLength: chunkLength, offset: 0, totalLength: totalLength)
+		XCTAssertEqual(HTTPMethodPut, request.httpMethod)
+		XCTAssertEqual("26", request.value(forHTTPHeaderField: "Content-Length"))
+		XCTAssertEqual("bytes 0-25/128", request.value(forHTTPHeaderField: "Content-Range"))
+		XCTAssertEqual(uploadURL, request.url)
+	}
+
+	func testFileCunkUploadRequestWithOffset() throws {
+		let uploadURL = URL(string: "example.com")!
+		let chunkLength = 26
+		let totalLength = 128
+		let request = provider.fileCunkUploadRequest(withUploadURL: uploadURL, chunkLength: chunkLength, offset: 26, totalLength: totalLength)
+		XCTAssertEqual(HTTPMethodPut, request.httpMethod)
+		XCTAssertEqual("26", request.value(forHTTPHeaderField: "Content-Length"))
+		XCTAssertEqual("bytes 26-51/128", request.value(forHTTPHeaderField: "Content-Range"))
+		XCTAssertEqual(uploadURL, request.url)
+	}
+
+	func testChildrenRequest() throws {
+		let item = OneDriveItem(path: CloudPath("/test"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .folder)
+		let request = try provider.childrenRequest(for: item)
+		XCTAssertEqual(HTTPMethodGet, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier/children")!, request.url)
+		XCTAssertNil(request.httpBody)
+	}
+
+	func testContentRequest() throws {
+		let item = OneDriveItem(path: CloudPath("/test"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .folder)
+		let request = try provider.contentRequest(for: item)
+		XCTAssertEqual(HTTPMethodGet, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier/content")!, request.url)
+		XCTAssertNil(request.httpBody)
+	}
+
+	func testCreateUploadSessionRequest() throws {
+		let item = OneDriveItem(path: CloudPath("/testFolder"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .folder)
+		let request = try provider.createUploadSessionRequest(forFilename: "Test.txt", parentItem: item)
+		XCTAssertEqual(HTTPMethodPost, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier:/Test.txt:/createUploadSession")!, request.url)
+		XCTAssertNil(request.httpBody)
+	}
+
+	func testCreateFolderRequest() throws {
+		let parentItem = OneDriveItem(path: CloudPath("/testFolder"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .folder)
+		let expectedRequestBody = "{\"@odata.type\":\"#microsoft.graph.driveItem\",\"name\":\"subFolder\",\"folder\":{}}"
+		let request = try provider.createFolderRequest(for: "subFolder", in: parentItem)
+		XCTAssertEqual(HTTPMethodPost, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier/children")!, request.url)
+		XCTAssertEqual(expectedRequestBody.data(using: .utf8), request.httpBody)
+	}
+
+	func testDeleteItemRequest() throws {
+		let item = OneDriveItem(path: CloudPath("/test.txt"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .file)
+		let request = try provider.deleteItemRequest(for: item)
+		XCTAssertEqual(HTTPMethodDelete, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier")!, request.url)
+		XCTAssertNil(request.httpBody)
+	}
+
+	func testMoveItemRequest() throws {
+		let item = OneDriveItem(path: CloudPath("/test.txt"), itemIdentifier: "TestIdentifier", driveIdentifier: nil, itemType: .file)
+		let newParentItem = OneDriveItem(path: CloudPath("/Folder"), itemIdentifier: "TestIdentifier-Folder", driveIdentifier: nil, itemType: .folder)
+		let targetCloudPath = CloudPath("/Folder/test.txt")
+		let expectedRequestBody = "{\"@odata.type\":\"#microsoft.graph.driveItem\",\"name\":\"test.txt\",\"parentReference\":{\"id\":\"TestIdentifier-Folder\"}}"
+		let request = try provider.moveItemRequest(for: item, newParentItem: newParentItem, targetCloudPath: targetCloudPath)
+		XCTAssertEqual(HTTPMethodPatch, request.httpMethod)
+		XCTAssertEqual(URL(string: "https://graph.microsoft.com/v1.0/me/drive/items/TestIdentifier")!, request.url)
+		XCTAssertEqual(expectedRequestBody.data(using: .utf8), request.httpBody)
+	}
+}
+
+private class MSAuthenticationProviderMock: NSObject, MSAuthenticationProvider {
+	func getAccessToken(for authProviderOptions: MSAuthenticationProviderOptions!, andCompletion completion: ((String?, Error?) -> Void)!) {
+		completion(nil, nil)
+	}
+}

--- a/create-integration-test-secrets-file.sh
+++ b/create-integration-test-secrets-file.sh
@@ -21,5 +21,9 @@ struct IntegrationTestSecrets {
 	static let googleDriveClientId = "${GOOGLE_DRIVE_CLIENT_ID}"
 	static let googleDriveRefreshToken = "${GOOGLE_DRIVE_REFRESH_TOKEN}"
 	static let webDAVCredential = WebDAVCredential(baseURL: URL(string: "${WEBDAV_BASE_URL}")!, username: "${WEBDAV_USERNAME}", password: "${WEBDAV_PASSWORD}", allowedCertificate: nil)
+	static let oneDriveClientId = "${ONEDRIVE_CLIENT_ID}"
+	static let oneDriveRedirectUri = "${ONEDRIVE_REDIRECT_URI}://auth"
+	static let oneDriveRefrehTokenData = "${ONEDRIVE_REFRESH_TOKEN_DATA}".data(using: .utf8)
+	static let oneDriveAccountData = "${ONEDRIVE_ACCOUNT_DATA}".data(using: .utf8)
 }
 EOM

--- a/create-integration-test-secrets-file.sh
+++ b/create-integration-test-secrets-file.sh
@@ -22,8 +22,8 @@ struct IntegrationTestSecrets {
 	static let googleDriveRefreshToken = "${GOOGLE_DRIVE_REFRESH_TOKEN}"
 	static let webDAVCredential = WebDAVCredential(baseURL: URL(string: "${WEBDAV_BASE_URL}")!, username: "${WEBDAV_USERNAME}", password: "${WEBDAV_PASSWORD}", allowedCertificate: nil)
 	static let oneDriveClientId = "${ONEDRIVE_CLIENT_ID}"
-	static let oneDriveRedirectUri = "${ONEDRIVE_REDIRECT_URI}://auth"
-	static let oneDriveRefrehTokenData = "${ONEDRIVE_REFRESH_TOKEN_DATA}".data(using: .utf8)
+	static let oneDriveRedirectUri = "${ONEDRIVE_REDIRECT_URI_SCHEME}://auth"
+	static let oneDriveRefreshTokenData = "${ONEDRIVE_REFRESH_TOKEN_DATA}".data(using: .utf8)
 	static let oneDriveAccountData = "${ONEDRIVE_ACCOUNT_DATA}".data(using: .utf8)
 }
 EOM


### PR DESCRIPTION
Introduces OneDrive as another cloud provider.
The minimum iOS version had to be raised from 10 to 11 due to Dependency `MSAL`.
Every upload is started as a chunked upload, since the maximum file size of 4mb is very low for a simple upload.

Currently we still have a problem to provide correct only Application Extension safe API. This is due to the upstream dependency `MSAL`, as it is delivered as a binary framework via SPM.

The IntegrationTests are already running successfully, but will only be committed as soon as a reasonable strategy for the IntegrationTestSecrets is in place. Currently there are too many individual Secrets that are needed for the OneDrive IntegrationTest.