### PR TITLE
Added support for S3 with a foreground URLSession

### DIFF
--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		4A628EB8252F610C0097DE94 /* URLSession+Promises.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A628EB7252F610C0097DE94 /* URLSession+Promises.swift */; };
 		4A6D2CD62643EE83006C5574 /* VaultProviderFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6D2CD52643EE83006C5574 /* VaultProviderFactoryTests.swift */; };
 		4A6E5DED252DC9480091E76D /* WebDAVSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6E5DEC252DC9480091E76D /* WebDAVSession.swift */; };
+		4A77390D286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A77390C286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift */; };
 		4A7C214D245305BB00DE81E6 /* CloudItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7C214C245305BB00DE81E6 /* CloudItemType.swift */; };
 		4AC75F9028607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC75F8F28607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift */; };
 		4AC75F9A2861A425002731FE /* VaultFormat7S3IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC75F992861A425002731FE /* VaultFormat7S3IntegrationTests.swift */; };
@@ -239,6 +240,7 @@
 		4A628EB7252F610C0097DE94 /* URLSession+Promises.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "URLSession+Promises.swift"; sourceTree = "<group>"; };
 		4A6D2CD52643EE83006C5574 /* VaultProviderFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultProviderFactoryTests.swift; sourceTree = "<group>"; };
 		4A6E5DEC252DC9480091E76D /* WebDAVSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVSession.swift; sourceTree = "<group>"; };
+		4A77390C286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSS3TransferUtility+ForegroundSession.swift"; sourceTree = "<group>"; };
 		4A7C214C245305BB00DE81E6 /* CloudItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudItemType.swift; sourceTree = "<group>"; };
 		4AC75F8F28607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAWSEndpointRegionNameStorage.swift; sourceTree = "<group>"; };
 		4AC75F992861A425002731FE /* VaultFormat7S3IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat7S3IntegrationTests.swift; sourceTree = "<group>"; };
@@ -655,6 +657,7 @@
 			children = (
 				4A0785352859FA820015DAE1 /* AWSEndpoint+CustomRegionName.swift */,
 				4A0785332859F5E30015DAE1 /* AWSS3+Promises.swift */,
+				4A77390C286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift */,
 				4AC75F8F28607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift */,
 				4AF0AA7D2844F38400C20B75 /* S3CloudProvider.swift */,
 				4A0785312859F5860015DAE1 /* S3CopyTaskUtility.swift */,
@@ -1196,6 +1199,7 @@
 				4A567B402615CD7D002C4D82 /* CloudPath+DatabaseValueConvertible.swift in Sources */,
 				4A567B042615C689002C4D82 /* DropboxClientSetup.swift in Sources */,
 				9ECEC0AF246ED1FB00151299 /* DirectoryIdCache.swift in Sources */,
+				4A77390D286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift in Sources */,
 				745949E225F22F4D00B7B28C /* VaultFormat8ProviderDecorator.swift in Sources */,
 				745949E625F2326D00B7B28C /* VaultFormat8ShorteningProviderDecorator.swift in Sources */,
 				4A628EB8252F610C0097DE94 /* URLSession+Promises.swift in Sources */,

--- a/Sources/CryptomatorCloudAccess/S3/AWSS3TransferUtility+ForegroundSession.swift
+++ b/Sources/CryptomatorCloudAccess/S3/AWSS3TransferUtility+ForegroundSession.swift
@@ -1,0 +1,51 @@
+//
+//  AWSS3TransferUtility+ForegroundSession.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 30.06.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import AWSS3
+import Foundation
+
+extension AWSS3TransferUtility {
+	private static let queue = DispatchQueue(label: "AWSS3TransferUtility-Swizzle")
+	private static var sessions = [ObjectIdentifier: URLSession]()
+	/// Contains the object identifiers of the AWSS3TransferUtilities which should use a foreground `URLSession`
+	private static var foregroundUtilities = NSHashTable<AWSS3TransferUtility>(options: .weakMemory)
+
+	static func useForegroundURLSession(for utility: AWSS3TransferUtility) {
+		allowOptionalForegroundURLSession
+		queue.sync {
+			foregroundUtilities.add(utility)
+		}
+	}
+
+	private static let allowOptionalForegroundURLSession: Void = {
+		guard let originalMethod = class_getInstanceMethod(AWSS3TransferUtility.self, Selector(("session"))), let swizzledMethod = class_getInstanceMethod(AWSS3TransferUtility.self, #selector(getter: foregroundURLSession)) else {
+			print("failed to swizzle useForegroundURLSession")
+			return
+		}
+		print("swizzled useForegroundURLSession")
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc var foregroundURLSession: URLSession {
+		return AWSS3TransferUtility.queue.sync {
+			guard AWSS3TransferUtility.foregroundUtilities.contains(self) else {
+				print("called background URLSession")
+				let originalBackgroundURLSession = foregroundURLSession
+				return originalBackgroundURLSession
+			}
+			print("called foregroundURLSession")
+			if let session = AWSS3TransferUtility.sessions[ObjectIdentifier(self)] {
+				return session
+			} else {
+				let session = URLSession(configuration: .default, delegate: self as? URLSessionDelegate, delegateQueue: nil)
+				AWSS3TransferUtility.sessions[ObjectIdentifier(self)] = session
+				return session
+			}
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/S3/S3Authenticator.swift
+++ b/Sources/CryptomatorCloudAccess/S3/S3Authenticator.swift
@@ -1,0 +1,24 @@
+//
+//  S3Authenticator.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 29.06.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import Promises
+
+public enum S3Authenticator {
+	public static func verifyCredential(_ credential: S3Credential) -> Promise<Void> {
+		let provider: S3CloudProvider
+		do {
+			provider = try S3CloudProvider(credential: credential)
+		} catch {
+			return Promise(error)
+		}
+		return provider.fetchItemList(forFolderAt: .root, withPageToken: nil).then { _ in
+			// no-op
+		}
+	}
+}

--- a/Sources/CryptomatorCloudAccess/S3/S3Credential.swift
+++ b/Sources/CryptomatorCloudAccess/S3/S3Credential.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-public struct S3Credential: Codable {
-	let accessKey: String
-	let secretKey: String
-	let url: URL
-	let bucket: String
-	let region: String
-	let identifier: String
+public struct S3Credential: Codable, Equatable {
+	public let accessKey: String
+	public let secretKey: String
+	public let url: URL
+	public let bucket: String
+	public let region: String
+	public let identifier: String
 
 	public init(accessKey: String, secretKey: String, url: URL, bucket: String, region: String, identifier: String = UUID().uuidString) {
 		self.accessKey = accessKey


### PR DESCRIPTION
This adds the possibility to use a `S3CloudProvider` with a foreground `URLSession`. Furthermore a `S3Authenticator` was added, which can be used to verify a `S3Credential`. For this a `S3CloudProvider` with a foreground `URLSession` is used to execute a `fetchItemList(forFolderAt:withPageToken:)` on the root directory. If this does not fail, we can assume that the passed `S3Credential` is correct.

In addition, a `sharedContainerIdentifier` can now be given to the `S3CloudProvider`, which is needed for using the background `URLSession` in an app extension.