### PR TITLE
Feature: Add background URLSession support to PCloudCloudProvider

### DIFF
--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
@@ -11,12 +11,12 @@ import PCloudSDKSwift
 import Promises
 
 public class PCloudCloudProvider: CloudProvider {
-	private let identifierCache: PCloudIdentifierCache
 	private let client: PCloudClient
+	private let identifierCache: PCloudIdentifierCache
 
 	public init(client: PCloudClient) throws {
-		self.identifierCache = try PCloudIdentifierCache()
 		self.client = client
+		self.identifierCache = try PCloudIdentifierCache()
 	}
 
 	public func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
@@ -11,12 +11,12 @@ import PCloudSDKSwift
 import Promises
 
 public class PCloudCloudProvider: CloudProvider {
-	private let credential: PCloudCredential
 	private let identifierCache: PCloudIdentifierCache
+	private let client: PCloudClient
 
-	public init(credential: PCloudCredential) throws {
-		self.credential = credential
+	public init(client: PCloudClient) throws {
 		self.identifierCache = try PCloudIdentifierCache()
+		self.client = client
 	}
 
 	public func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
@@ -134,7 +134,7 @@ public class PCloudCloudProvider: CloudProvider {
 	private func fetchFileMetadata(for item: PCloudItem) -> Promise<CloudItemMetadata> {
 		assert(item.itemType == .file)
 		CloudAccessDDLogDebug("PCloudCloudProvider: fetchFileMetadata(for: \(item.identifier)) called")
-		return credential.client.getFileMetadata(item.identifier).execute().then { metadata -> CloudItemMetadata in
+		return client.getFileMetadata(item.identifier).execute().then { metadata -> CloudItemMetadata in
 			CloudAccessDDLogDebug("PCloudCloudProvider: fetchFileMetadata(for: \(item.identifier)) received metadata: \(metadata)")
 			try self.identifierCache.addOrUpdate(item)
 			return self.convertToCloudItemMetadata(metadata, at: item.cloudPath)
@@ -154,7 +154,7 @@ public class PCloudCloudProvider: CloudProvider {
 	private func fetchFolderMetadata(for item: PCloudItem) -> Promise<CloudItemMetadata> {
 		assert(item.itemType == .folder)
 		CloudAccessDDLogDebug("PCloudCloudProvider: fetchFolderMetadata(for: \(item.identifier)) called")
-		return credential.client.listFolder(item.identifier, recursively: false).execute().then { metadata -> CloudItemMetadata in
+		return client.listFolder(item.identifier, recursively: false).execute().then { metadata -> CloudItemMetadata in
 			CloudAccessDDLogDebug("PCloudCloudProvider: fetchFolderMetadata(for: \(item.identifier)) received metadata: \(metadata)")
 			try self.identifierCache.addOrUpdate(item)
 			return self.convertToCloudItemMetadata(metadata, at: item.cloudPath)
@@ -178,7 +178,7 @@ public class PCloudCloudProvider: CloudProvider {
 			CloudAccessDDLogDebug("PCloudCloudProvider: fetchItemList(for: \(item.identifier)) failed with error: \(error)")
 			return Promise(error)
 		}
-		return credential.client.listFolder(item.identifier, recursively: false).execute().then { metadata -> CloudItemList in
+		return client.listFolder(item.identifier, recursively: false).execute().then { metadata -> CloudItemList in
 			CloudAccessDDLogDebug("PCloudCloudProvider: fetchItemList(for: \(item.identifier)) received metadata: \(metadata)")
 			for content in metadata.contents {
 				guard let name = content.fileMetadata?.name ?? content.folderMetadata?.name else {
@@ -220,7 +220,7 @@ public class PCloudCloudProvider: CloudProvider {
 			CloudAccessDDLogDebug("PCloudCloudProvider: getFileLink(for: \(item.identifier)) failed with error: \(error)")
 			return Promise(error)
 		}
-		return credential.client.getFileLink(forFile: item.identifier).execute().then { metadata -> FileLink.Metadata in
+		return client.getFileLink(forFile: item.identifier).execute().then { metadata -> FileLink.Metadata in
 			CloudAccessDDLogDebug("PCloudCloudProvider: getFileLink(for: \(item.identifier)) received metadata: \(metadata)")
 			if let first = metadata.first {
 				return first
@@ -242,7 +242,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func downloadFileLink(_ fileLink: FileLink.Metadata, to localURL: URL, with progress: Progress) -> Promise<URL> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: downloadFileLink(\(fileLink), to: \(localURL)) called")
-		let task = credential.client.downloadFile(from: fileLink.address, downloadTag: fileLink.downloadTag, to: { tmpURL in
+		let task = client.downloadFile(from: fileLink.address, downloadTag: fileLink.downloadTag, to: { tmpURL in
 			try FileManager.default.moveItem(at: tmpURL, to: localURL)
 			return localURL
 		})
@@ -262,7 +262,7 @@ public class PCloudCloudProvider: CloudProvider {
 	private func uploadFile(for parentItem: PCloudItem, from localURL: URL, to cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: uploadFile(for: \(parentItem.identifier), from: \(localURL), to: \(cloudPath.path)) called")
 		let progress = Progress(totalUnitCount: -1)
-		let task = credential.client.upload(fromFileAt: localURL, toFolder: parentItem.identifier, asFileNamed: cloudPath.lastPathComponent)
+		let task = client.upload(fromFileAt: localURL, toFolder: parentItem.identifier, asFileNamed: cloudPath.lastPathComponent)
 		task.addProgressBlock { numberOfBytesSent, totalNumberOfBytesToSend in
 			progress.totalUnitCount = totalNumberOfBytesToSend
 			progress.completedUnitCount = numberOfBytesSent
@@ -287,7 +287,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func createFolder(for parentItem: PCloudItem, with name: String) -> Promise<Void> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: createFolder(for: \(parentItem.identifier), with: \(name)) called")
-		return credential.client.createFolder(named: name, inFolder: parentItem.identifier).execute().then { metadata -> Void in
+		return client.createFolder(named: name, inFolder: parentItem.identifier).execute().then { metadata -> Void in
 			CloudAccessDDLogDebug("PCloudCloudProvider: createFolder(for: \(parentItem.identifier), with: \(name)) received metadata: \(metadata)")
 			let cloudPath = parentItem.cloudPath.appendingPathComponent(name)
 			let item = PCloudItem(cloudPath: cloudPath, metadata: metadata)
@@ -309,7 +309,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func deleteFile(for item: PCloudItem) -> Promise<Void> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: deleteFile(for: \(item.identifier)) called")
-		return credential.client.deleteFile(item.identifier).execute().then { metadata -> Void in
+		return client.deleteFile(item.identifier).execute().then { metadata -> Void in
 			CloudAccessDDLogDebug("PCloudCloudProvider: deleteFile(for: \(item.identifier)) received metadata: \(metadata)")
 			try self.identifierCache.invalidate(item)
 		}.recover { error -> Void in
@@ -327,7 +327,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func deleteFolder(for item: PCloudItem) -> Promise<Void> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: deleteFolder(for: \(item.identifier)) called")
-		return credential.client.deleteFolderRecursively(item.identifier).execute().then { metadata -> Void in
+		return client.deleteFolderRecursively(item.identifier).execute().then { metadata -> Void in
 			CloudAccessDDLogDebug("PCloudCloudProvider: deleteFolder(for: \(item.identifier)) received metadata: \(metadata)")
 			try self.identifierCache.invalidate(item)
 		}.recover { error -> Void in
@@ -345,7 +345,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func moveFile(from sourceItem: PCloudItem, toParent targetParentItem: PCloudItem, targetCloudPath: CloudPath) -> Promise<Void> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: moveFile(from: \(sourceItem.identifier), toParent: \(targetParentItem.identifier), targetCloudPath: \(targetCloudPath.path)) called")
-		return credential.client.moveFile(sourceItem.identifier, toFolder: targetParentItem.identifier, newName: targetCloudPath.lastPathComponent).execute().then { metadata -> Void in
+		return client.moveFile(sourceItem.identifier, toFolder: targetParentItem.identifier, newName: targetCloudPath.lastPathComponent).execute().then { metadata -> Void in
 			CloudAccessDDLogDebug("PCloudCloudProvider: moveFile(from: \(sourceItem.identifier), toParent: \(targetParentItem.identifier), targetCloudPath: \(targetCloudPath.path)) received metadata: \(metadata)")
 			try self.identifierCache.invalidate(sourceItem)
 			let targetItem = PCloudItem(cloudPath: targetCloudPath, metadata: metadata)
@@ -367,7 +367,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func moveFolder(from sourceItem: PCloudItem, toParent targetParentItem: PCloudItem, targetCloudPath: CloudPath) -> Promise<Void> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: moveFolder(from: \(sourceItem.identifier), toParent: \(targetParentItem.identifier), targetCloudPath: \(targetCloudPath.path)) called")
-		return credential.client.moveFolder(sourceItem.identifier, toFolder: targetParentItem.identifier, newName: targetCloudPath.lastPathComponent).execute().then { metadata -> Void in
+		return client.moveFolder(sourceItem.identifier, toFolder: targetParentItem.identifier, newName: targetCloudPath.lastPathComponent).execute().then { metadata -> Void in
 			CloudAccessDDLogDebug("PCloudCloudProvider: moveFolder(from: \(sourceItem.identifier), toParent: \(targetParentItem.identifier), targetCloudPath: \(targetCloudPath.path)) received metadata: \(metadata)")
 			try self.identifierCache.invalidate(sourceItem)
 			let targetItem = PCloudItem(cloudPath: targetCloudPath, metadata: metadata)
@@ -435,7 +435,7 @@ public class PCloudCloudProvider: CloudProvider {
 
 	private func getPCloudItem(for name: String, withParentItem parentItem: PCloudItem) -> Promise<PCloudItem> {
 		CloudAccessDDLogDebug("PCloudCloudProvider: getPCloudItem(for: \(name), withParentItem: \(parentItem.identifier)) called")
-		return credential.client.listFolder(parentItem.identifier, recursively: false).execute().then { metadata -> PCloudItem in
+		return client.listFolder(parentItem.identifier, recursively: false).execute().then { metadata -> PCloudItem in
 			CloudAccessDDLogDebug("PCloudCloudProvider: getPCloudItem(for: \(name), withParentItem: \(parentItem.identifier)) received metadata: \(metadata)")
 			guard let content = metadata.contents.first(where: { $0.fileMetadata?.name == name || $0.folderMetadata?.name == name }) else {
 				throw CloudProviderError.itemNotFound

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
@@ -11,11 +11,12 @@ import PCloudSDKSwift
 import Promises
 
 public class PCloudCredential {
-	public let client: PCloudClient
 	public let user: OAuth.User
 	public var userID: String {
 		return String(user.id)
 	}
+
+	private let client: PCloudClient
 
 	public init(user: OAuth.User) {
 		self.user = user
@@ -26,5 +27,53 @@ public class PCloudCredential {
 		return client.fetchUserInfo().execute().then { metadata in
 			return metadata.emailAddress
 		}
+	}
+}
+
+extension PCloud {
+	/// Creates a pCloud client with a background `URLSession`. Does not update the `sharedClient` property. You are responsible for storing it and keeping it alive. Use if
+	/// you want a more direct control over the lifetime of the `PCloudClient` object. Multiple clients can exist simultaneously.
+	///
+	/// - parameter user: A `OAuth.User` value obtained from the keychain or the OAuth flow.
+	/// - parameter sharedContainerIdentifier: To create a URL session for use by an app extension, set this property to a valid identifier for a container shared between the app extension and its containing app
+	/// - returns: An instance of a `PCloudClient` ready to take requests.
+	public static func createBackgroundClient(with user: OAuth.User, sharedContainerIdentifier: String? = nil) -> PCloudClient {
+		let bundleId = Bundle.main.bundleIdentifier ?? ""
+		return createBackgroundClient(withAccessToken: user.token, apiHostName: user.httpAPIHostName, sessionIdentifier: "pCloud - \(user.id) - \(bundleId)", sharedContainerIdentifier: sharedContainerIdentifier)
+	}
+
+	private static func createBackgroundClient(withAccessToken accessToken: String, apiHostName: String, sessionIdentifier: String, sharedContainerIdentifier: String?) -> PCloudClient {
+		let authenticator = OAuthAccessTokenBasedAuthenticator(accessToken: accessToken)
+		let eventHub = URLSessionEventHub()
+		var configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
+		configuration.sharedContainerIdentifier = sharedContainerIdentifier
+		let session = URLSession(configuration: configuration, delegate: eventHub, delegateQueue: nil)
+		let foregroundSession = URLSession(configuration: .default, delegate: eventHub, delegateQueue: nil)
+
+		// The event hub is expected to be kept in memory by the operation builder blocks.
+
+		let callOperationBuilder = URLSessionBasedNetworkOperationUtilities.createCallOperationBuilder(with: .https,
+		                                                                                               session: foregroundSession,
+		                                                                                               delegate: eventHub)
+
+		let uploadOperationBuilder = URLSessionBasedNetworkOperationUtilities.createUploadOperationBuilder(with: .https,
+		                                                                                                   session: session,
+		                                                                                                   delegate: eventHub)
+
+		let downloadOperationBuilder = URLSessionBasedNetworkOperationUtilities.createDownloadOperationBuilder(with: session, delegate: eventHub)
+
+		let callTaskBuilder = PCloudAPICallTaskBuilder(hostProvider: apiHostName,
+		                                               authenticator: authenticator,
+		                                               operationBuilder: callOperationBuilder)
+
+		let uploadTaskBuilder = PCloudAPIUploadTaskBuilder(hostProvider: apiHostName,
+		                                                   authenticator: authenticator,
+		                                                   operationBuilder: uploadOperationBuilder)
+
+		let downloadTaskBuilder = PCloudAPIDownloadTaskBuilder(hostProvider: apiHostName,
+		                                                       authenticator: authenticator,
+		                                                       operationBuilder: downloadOperationBuilder)
+
+		return PCloudClient(callTaskBuilder: callTaskBuilder, uploadTaskBuilder: uploadTaskBuilder, downloadTaskBuilder: downloadTaskBuilder)
 	}
 }

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
@@ -31,12 +31,15 @@ public class PCloudCredential {
 }
 
 extension PCloud {
-	/// Creates a pCloud client with a background `URLSession`. Does not update the `sharedClient` property. You are responsible for storing it and keeping it alive. Use if
-	/// you want a more direct control over the lifetime of the `PCloudClient` object. Multiple clients can exist simultaneously.
-	///
-	/// - parameter user: A `OAuth.User` value obtained from the keychain or the OAuth flow.
-	/// - parameter sharedContainerIdentifier: To create a URL session for use by an app extension, set this property to a valid identifier for a container shared between the app extension and its containing app
-	/// - returns: An instance of a `PCloudClient` ready to take requests.
+	/**
+	 Creates a pCloud client with a background `URLSession`.
+
+	 Does not update the `sharedClient` property. You are responsible for storing it and keeping it alive. Use if you want a more direct control over the lifetime of the `PCloudClient` object. Multiple clients can exist simultaneously.
+
+	 - Parameter user: A `OAuth.User` value obtained from the keychain or the OAuth flow.
+	 - Parameter sharedContainerIdentifier: To create a URL session for use by an app extension, set this property to a valid identifier for a container shared between the app extension and its containing app.
+	 - Returns: An instance of a `PCloudClient` ready to take requests.
+	 */
 	public static func createBackgroundClient(with user: OAuth.User, sharedContainerIdentifier: String? = nil) -> PCloudClient {
 		let bundleId = Bundle.main.bundleIdentifier ?? ""
 		return createBackgroundClient(withAccessToken: user.token, apiHostName: user.httpAPIHostName, sessionIdentifier: "pCloud - \(user.id) - \(bundleId)", sharedContainerIdentifier: sharedContainerIdentifier)
@@ -51,29 +54,12 @@ extension PCloud {
 		let foregroundSession = URLSession(configuration: .default, delegate: eventHub, delegateQueue: nil)
 
 		// The event hub is expected to be kept in memory by the operation builder blocks.
-
-		let callOperationBuilder = URLSessionBasedNetworkOperationUtilities.createCallOperationBuilder(with: .https,
-		                                                                                               session: foregroundSession,
-		                                                                                               delegate: eventHub)
-
-		let uploadOperationBuilder = URLSessionBasedNetworkOperationUtilities.createUploadOperationBuilder(with: .https,
-		                                                                                                   session: session,
-		                                                                                                   delegate: eventHub)
-
+		let callOperationBuilder = URLSessionBasedNetworkOperationUtilities.createCallOperationBuilder(with: .https, session: foregroundSession, delegate: eventHub)
+		let uploadOperationBuilder = URLSessionBasedNetworkOperationUtilities.createUploadOperationBuilder(with: .https, session: session, delegate: eventHub)
 		let downloadOperationBuilder = URLSessionBasedNetworkOperationUtilities.createDownloadOperationBuilder(with: session, delegate: eventHub)
-
-		let callTaskBuilder = PCloudAPICallTaskBuilder(hostProvider: apiHostName,
-		                                               authenticator: authenticator,
-		                                               operationBuilder: callOperationBuilder)
-
-		let uploadTaskBuilder = PCloudAPIUploadTaskBuilder(hostProvider: apiHostName,
-		                                                   authenticator: authenticator,
-		                                                   operationBuilder: uploadOperationBuilder)
-
-		let downloadTaskBuilder = PCloudAPIDownloadTaskBuilder(hostProvider: apiHostName,
-		                                                       authenticator: authenticator,
-		                                                       operationBuilder: downloadOperationBuilder)
-
+		let callTaskBuilder = PCloudAPICallTaskBuilder(hostProvider: apiHostName, authenticator: authenticator, operationBuilder: callOperationBuilder)
+		let uploadTaskBuilder = PCloudAPIUploadTaskBuilder(hostProvider: apiHostName, authenticator: authenticator, operationBuilder: uploadOperationBuilder)
+		let downloadTaskBuilder = PCloudAPIDownloadTaskBuilder(hostProvider: apiHostName, authenticator: authenticator, operationBuilder: downloadOperationBuilder)
 		return PCloudClient(callTaskBuilder: callTaskBuilder, uploadTaskBuilder: uploadTaskBuilder, downloadTaskBuilder: downloadTaskBuilder)
 	}
 }

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6PCloudIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6PCloudIntegrationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Skymatic GmbH. All rights reserved.
 //
 
+import PCloudSDKSwift
 import XCTest
 #if canImport(CryptomatorCloudAccessCore)
 @testable import CryptomatorCloudAccessCore
@@ -20,8 +21,9 @@ class VaultFormat6PCloudIntegrationTests: CloudAccessIntegrationTest {
 	}
 
 	private static let credential = PCloudCredentialMock()
+	private static let client = PCloud.createClient(with: credential.user)
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! PCloudCloudProvider(credential: credential)
+	private static let cloudProvider = try! PCloudCloudProvider(client: client)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat6")
 
 	override class func setUp() {

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7PCloudIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7PCloudIntegrationTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Skymatic GmbH. All rights reserved.
 //
 
+import PCloudSDKSwift
 import XCTest
 #if canImport(CryptomatorCloudAccessCore)
 @testable import CryptomatorCloudAccessCore
@@ -20,8 +21,10 @@ class VaultFormat7PCloudIntegrationTests: CloudAccessIntegrationTest {
 	}
 
 	private static let credential = PCloudCredentialMock()
+	private static let client = PCloud.createClient(with: credential.user)
+
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! PCloudCloudProvider(credential: credential)
+	private static let cloudProvider = try! PCloudCloudProvider(client: client)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat7")
 
 	override class func setUp() {

--- a/Tests/CryptomatorCloudAccessIntegrationTests/PCloud/PCloudCloudProviderIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/PCloud/PCloudCloudProviderIntegrationTests.swift
@@ -11,6 +11,7 @@ import CryptomatorCloudAccessCore
 #else
 import CryptomatorCloudAccess
 #endif
+import PCloudSDKSwift
 import Promises
 import XCTest
 
@@ -24,20 +25,23 @@ class PCloudCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAuthent
 	override class func setUp() {
 		integrationTestParentCloudPath = CloudPath("/iOS-IntegrationTests-Plain")
 		let credential = PCloudCredentialMock()
+		let client = PCloud.createClient(with: credential.user)
 		// swiftlint:disable:next force_try
-		setUpProvider = try! PCloudCloudProvider(credential: credential)
+		setUpProvider = try! PCloudCloudProvider(client: client)
 		super.setUp()
 	}
 
 	override func setUpWithError() throws {
 		try super.setUpWithError()
-		provider = try PCloudCloudProvider(credential: credential)
+		let client = PCloud.createClient(with: credential.user)
+		provider = try PCloudCloudProvider(client: client)
 	}
 
 	override func deauthenticate() -> Promise<Void> {
 		let invalidCredential = PCloudInvalidCredentialMock()
+		let client = PCloud.createClient(with: invalidCredential.user)
 		// swiftlint:disable:next force_try
-		provider = try! PCloudCloudProvider(credential: invalidCredential)
+		provider = try! PCloudCloudProvider(client: client)
 		return Promise(())
 	}
 


### PR DESCRIPTION
Adds background `URLSession` support to the `PCloudCloudProvider`.

The background `URLSession` will only be used for download and uploads. Simple request which require a DataTask (like fetchItemList, etc.) will be executed with a default (foreground) `URLSession`.