### PR TITLE
Feature: Download progress

### DIFF
--- a/Sources/CryptomatorCloudAccess/API/CloudProvider+Convenience.swift
+++ b/Sources/CryptomatorCloudAccess/API/CloudProvider+Convenience.swift
@@ -81,4 +81,8 @@ public extension CloudProvider {
 			}
 		}
 	}
+
+	func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+		downloadFile(from: cloudPath, to: localURL, onTaskCreation: nil)
+	}
 }

--- a/Sources/CryptomatorCloudAccess/API/CloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/API/CloudProvider.swift
@@ -45,6 +45,7 @@ public protocol CloudProvider {
 
 	 - Parameter cloudPath: The cloud path of the file to download.
 	 - Parameter localURL: The local URL of the desired download location.
+	 - Parameter onTaskCreation: Gets called once the provider created the underlying `URLSessionDownloadTask`. This can be called with `nil` if the provider does not provide a `URLSessionDownloadTask`.
 	 - Precondition: `localURL` must be a file URL.
 	 - Postcondition: The file is stored at `localURL`.
 	 - Returns: Empty promise. If the download fails, promise is rejected with:
@@ -54,7 +55,7 @@ public protocol CloudProvider {
 	   - `CloudProviderError.unauthorized` if the request lacks valid authentication credentials.
 	   - `CloudProviderError.noInternetConnection` if there is no internet connection to handle the request.
 	 */
-	func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void>
+	func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void>
 
 	/**
 	 Uploads a file.

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ProviderDecorator.swift
@@ -73,7 +73,7 @@ class VaultFormat6ProviderDecorator: CloudProvider {
 		}
 	}
 
-	func downloadFile(from cleartextCloudPath: CloudPath, to cleartextLocalURL: URL) -> Promise<Void> {
+	func downloadFile(from cleartextCloudPath: CloudPath, to cleartextLocalURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(cleartextLocalURL.isFileURL)
 		let overallProgress = Progress(totalUnitCount: 5)
 		let ciphertextLocalURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecorator.swift
@@ -59,7 +59,7 @@ class VaultFormat6ShorteningProviderDecorator: CloudProvider {
 		}
 	}
 
-	func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		let shortened = shortenedNameCache.getShortenedPath(cloudPath)
 		return delegate.downloadFile(from: shortened.cloudPath, to: localURL)

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ProviderDecorator.swift
@@ -70,13 +70,13 @@ class VaultFormat7ProviderDecorator: CloudProvider {
 		}
 	}
 
-	func downloadFile(from cleartextCloudPath: CloudPath, to cleartextLocalURL: URL) -> Promise<Void> {
+	func downloadFile(from cleartextCloudPath: CloudPath, to cleartextLocalURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(cleartextLocalURL.isFileURL)
 		let overallProgress = Progress(totalUnitCount: 5)
 		let ciphertextLocalURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		return getC9RPath(cleartextCloudPath).then { ciphertextCloudPath in
 			overallProgress.becomeCurrent(withPendingUnitCount: 4)
-			let downloadFilePromise = self.delegate.downloadFile(from: ciphertextCloudPath, to: ciphertextLocalURL)
+			let downloadFilePromise = self.delegate.downloadFile(from: ciphertextCloudPath, to: ciphertextLocalURL, onTaskCreation: onTaskCreation)
 			overallProgress.resignCurrent()
 			return downloadFilePromise
 		}.then {

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecorator.swift
@@ -75,14 +75,14 @@ class VaultFormat7ShorteningProviderDecorator: CloudProvider {
 		}
 	}
 
-	func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		let shortened = shortenedNameCache.getShortenedPath(cloudPath)
 		if shortened.pointsToC9S {
 			let contentsFilePath = shortened.cloudPath.appendingContentsFileComponent()
-			return delegate.downloadFile(from: contentsFilePath, to: localURL)
+			return delegate.downloadFile(from: contentsFilePath, to: localURL, onTaskCreation: onTaskCreation)
 		} else {
-			return delegate.downloadFile(from: shortened.cloudPath, to: localURL)
+			return delegate.downloadFile(from: shortened.cloudPath, to: localURL, onTaskCreation: onTaskCreation)
 		}
 	}
 

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
@@ -63,7 +63,7 @@ public class DropboxCloudProvider: CloudProvider {
 		}, condition: shouldRetryForError)
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		guard let authorizedClient = credential.authorizedClient else {
 			return Promise(CloudProviderError.unauthorized)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -107,7 +107,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		let progress = Progress(totalUnitCount: 1)
 		return resolvePath(forItemAt: cloudPath).then { item -> Promise<Void> in
 			progress.becomeCurrent(withPendingUnitCount: 1)
-			let downloadPromise = self.downloadFile(for: item, to: localURL)
+			let downloadPromise = self.downloadFile(for: item, to: localURL, onTaskCreation: onTaskCreation)
 			progress.resignCurrent()
 			return downloadPromise
 		}
@@ -233,7 +233,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	private func downloadFile(for item: GoogleDriveItem, to localURL: URL) -> Promise<Void> {
+	private func downloadFile(for item: GoogleDriveItem, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		CloudAccessDDLogDebug("GoogleDriveCloudProvider: downloadFile(for: \(item.identifier), to: \(localURL)) called")
 		guard item.itemType == .file || (item.itemType == .symlink && item.shortcut?.targetItemType == .file) else {
 			return Promise(CloudProviderError.itemTypeMismatch)
@@ -247,7 +247,13 @@ public class GoogleDriveCloudProvider: CloudProvider {
 			progress.totalUnitCount = totalBytesExpectedToWrite // Unnecessary to set several times
 			progress.completedUnitCount = totalBytesWritten
 		}
-		return executeFetcher(fetcher)
+		return executeFetcher(fetcher) { sessionTask in
+			guard let downloadTask = sessionTask as? URLSessionDownloadTask else {
+				CloudAccessDDLogDebug("GoogleDriveCloudProvider: executeFetcher returned an unexpected URLSessionTask")
+				return
+			}
+			onTaskCreation?(downloadTask)
+		}
 	}
 
 	private func uploadFile(for parentItem: GoogleDriveItem, from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
@@ -552,7 +558,8 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	private func executeFetcher(_ fetcher: GTMSessionFetcher) -> Promise<Void> {
+	private func executeFetcher(_ fetcher: GTMSessionFetcher, onTaskCreation: @escaping (URLSessionTask?) -> Void) -> Promise<Void> {
+		var kvoToken: NSKeyValueObservation?
 		return Promise<Void> { fulfill, reject in
 			self.runningFetchers.append(fetcher)
 			fetcher.beginFetch { _, error in
@@ -570,6 +577,14 @@ public class GoogleDriveCloudProvider: CloudProvider {
 				}
 				fulfill(())
 			}
+			kvoToken = fetcher.observe(\.sessionTask, options: [.new], changeHandler: { _, change in
+				guard let newValue = change.newValue, let sessionTask = newValue else {
+					return
+				}
+				onTaskCreation(sessionTask)
+			})
+		}.always {
+			kvoToken?.invalidate()
 		}
 	}
 

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -99,7 +99,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		if FileManager.default.fileExists(atPath: localURL.path) {
 			return Promise(CloudProviderError.itemAlreadyExists)

--- a/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
+++ b/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
@@ -178,7 +178,7 @@ public class LocalFileSystemProvider: CloudProvider {
 		return Promise(CloudItemList(items: cacheResponse.elements, nextPageToken: cacheResponse.nextPageToken))
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		let url = rootURL.appendingPathComponent(cloudPath)
 		let shouldStopAccessing = url.startAccessingSecurityScopedResource()

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -59,7 +59,7 @@ public class OneDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		if FileManager.default.fileExists(atPath: localURL.path) {
 			return Promise(CloudProviderError.itemAlreadyExists)

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
@@ -34,7 +34,7 @@ public class PCloudCloudProvider: CloudProvider {
 		}
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		if FileManager.default.fileExists(atPath: localURL.path) {
 			return Promise(CloudProviderError.itemAlreadyExists)

--- a/Sources/CryptomatorCloudAccess/S3/S3CloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/S3/S3CloudProvider.swift
@@ -113,7 +113,7 @@ public class S3CloudProvider: CloudProvider {
 		}
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		CloudAccessDDLogDebug("S3CloudProvider: downloadFile(from: \(cloudPath.path), to: \(localURL)) called")
 		if FileManager.default.fileExists(atPath: localURL.path) {
 			return Promise(CloudProviderError.itemAlreadyExists)

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
@@ -69,7 +69,7 @@ public class WebDAVClient {
 		request.httpBody = """
 		<?xml version="1.0" encoding="utf-8"?><d:propfind xmlns:d="DAV:">\(propfindPropElementsAsXML(with: propertyNames))</d:propfind>
 		""".data(using: .utf8)
-		return webDAVSession.performDownloadTask(with: request, to: localURL)
+		return webDAVSession.performDownloadTask(with: request, to: localURL, onTaskCreation: nil)
 	}
 
 	public func PROPFIND(url: URL, depth: PropfindDepth, propertyNames: [String]? = nil) -> Promise<(HTTPURLResponse, Data?)> {
@@ -83,10 +83,10 @@ public class WebDAVClient {
 		return webDAVSession.performDataTask(with: request)
 	}
 
-	public func GET(from url: URL, to localURL: URL) -> Promise<HTTPURLResponse> {
+	public func GET(from url: URL, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<HTTPURLResponse> {
 		var request = URLRequest(url: url)
 		request.httpMethod = "GET"
-		return webDAVSession.performDownloadTask(with: request, to: localURL)
+		return webDAVSession.performDownloadTask(with: request, to: localURL, onTaskCreation: onTaskCreation)
 	}
 
 	public func PUT(url: URL, fileURL: URL) -> Promise<(HTTPURLResponse, Data?)> {

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
@@ -120,7 +120,7 @@ public class WebDAVProvider: CloudProvider {
 				throw CloudProviderError.itemTypeMismatch
 			}
 			progress.becomeCurrent(withPendingUnitCount: 1)
-			let getPromise = self.client.GET(from: url, to: localURL)
+			let getPromise = self.client.GET(from: url, to: localURL, onTaskCreation: onTaskCreation)
 			progress.resignCurrent()
 			return getPromise
 		}.then { _ -> Void in

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
@@ -107,7 +107,7 @@ public class WebDAVProvider: CloudProvider {
 		return CloudItemList(items: response.elements, nextPageToken: response.nextPageToken)
 	}
 
-	public func downloadFile(from cloudPath: CloudPath, to localURL: URL) -> Promise<Void> {
+	public func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		guard let url = URL(cloudPath: cloudPath, relativeTo: client.baseURL) else {
 			return Promise(WebDAVProviderError.resolvingURLFailed)

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
@@ -217,10 +217,11 @@ class WebDAVSession {
 		}
 	}
 
-	func performDownloadTask(with request: URLRequest, to localURL: URL) -> Promise<HTTPURLResponse> {
+	func performDownloadTask(with request: URLRequest, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<HTTPURLResponse> {
 		HTTPDebugLogger.logRequest(request)
 		let progress = Progress(totalUnitCount: 1)
 		let task = urlSession.downloadTask(with: request)
+		onTaskCreation?(task)
 		progress.addChild(task.progress, withPendingUnitCount: 1)
 		let pendingPromise = Promise<HTTPURLResponse>.pending()
 		let webDAVDownloadTask = WebDAVDownloadTask(promise: pendingPromise, localURL: localURL)


### PR DESCRIPTION
Changes the CloudProvider API to return an optional `URLSessionDownloadTask` on task creation.

Rationale:

The FileProviderExtension only reports the download progress when we actually register a _real_ URLSessionTask via NSFileProviderManager.register(…) ([Documentation](https://developer.apple.com/documentation/fileprovider/nsfileprovidermanager/2890932-register)).
Therefore, we need to return the `URLSessionDownloadTask` via the CloudProvider as soon as this task has been created.
For now this can be tested with WebDAV and Google Drive.

For some CloudProviders the onTaskCreation closure will never be called as they simply to not have a `URLSessionDownloadTask` like the `LocalFileSystemProvider`. Unfortunately this also implies that we can not report the download progress for iCloud Drive.