### PR TITLE
Feature: Upload progress

### DIFF
--- a/Sources/CryptomatorCloudAccess/API/CloudProvider+Convenience.swift
+++ b/Sources/CryptomatorCloudAccess/API/CloudProvider+Convenience.swift
@@ -32,6 +32,13 @@ public extension CloudProvider {
 	}
 
 	/**
+	 Convenience wrapper for `uploadFile()` that ignores the underlying task.
+	 */
+	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+		uploadFile(from: localURL, to: cloudPath, replaceExisting: replaceExisting, onTaskCreation: nil)
+	}
+
+	/**
 	 Convenience wrapper for `createFolder()` that also satisfies if the item is present.
 	 */
 	func createFolderIfMissing(at cloudPath: CloudPath) -> Promise<Void> {

--- a/Sources/CryptomatorCloudAccess/API/CloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/API/CloudProvider.swift
@@ -65,6 +65,7 @@ public protocol CloudProvider {
 	 - Parameter localURL: The local URL of the file to upload.
 	 - Parameter cloudPath: The cloud path of the desired upload location.
 	 - Parameter replaceExisting: If true, overwrite the existing file at `cloudPath`.
+	 - Parameter onTaskCreation: Gets called once the provider created the underlying `URLSessionUploadTask`. This can be called with `nil` if the provider does not provide a `URLSessionUploadTask`.
 	 - Precondition: `localURL` must be a file URL.
 	 - Postcondition: The file is stored at `cloudPath`.
 	 - Postcondition: The `size` property of the returned metadata is set to the size of the uploaded file in the cloud and must not be `nil`.
@@ -77,7 +78,7 @@ public protocol CloudProvider {
 	   - `CloudProviderError.unauthorized` if the request lacks valid authentication credentials.
 	   - `CloudProviderError.noInternetConnection` if there is no internet connection to handle the request.
 	 */
-	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata>
+	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata>
 
 	/**
 	 Creates a folder.

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ProviderDecorator.swift
@@ -107,7 +107,7 @@ class VaultFormat6ProviderDecorator: CloudProvider {
 		}
 	}
 
-	func uploadFile(from cleartextLocalURL: URL, to cleartextCloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	func uploadFile(from cleartextLocalURL: URL, to cleartextCloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(cleartextLocalURL.isFileURL)
 		let overallProgress = Progress(totalUnitCount: 5)
 		let ciphertextLocalURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
@@ -129,7 +129,7 @@ class VaultFormat6ProviderDecorator: CloudProvider {
 			try self.cryptor.encryptContent(from: cleartextLocalURL, to: ciphertextLocalURL)
 			overallProgress.resignCurrent()
 			overallProgress.becomeCurrent(withPendingUnitCount: 4)
-			let uploadFilePromise = self.delegate.uploadFile(from: ciphertextLocalURL, to: fileCiphertextPath, replaceExisting: replaceExisting)
+			let uploadFilePromise = self.delegate.uploadFile(from: ciphertextLocalURL, to: fileCiphertextPath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 			overallProgress.resignCurrent()
 			return uploadFilePromise
 		}.recover { error -> CloudItemMetadata in

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecorator.swift
@@ -65,17 +65,17 @@ class VaultFormat6ShorteningProviderDecorator: CloudProvider {
 		return delegate.downloadFile(from: shortened.cloudPath, to: localURL, onTaskCreation: onTaskCreation)
 	}
 
-	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		let shortened = shortenedNameCache.getShortenedPath(cloudPath)
 		if shortened.pointsToLNG {
 			return uploadNameFile(shortened.cloudPath.lastPathComponent, originalName: cloudPath.lastPathComponent).then {
-				return self.delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting)
+				return self.delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 			}.then { shortenedMetadata in
 				return self.getOriginalMetadata(shortenedMetadata)
 			}
 		} else {
-			return delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting)
+			return delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 		}
 	}
 

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ProviderDecorator.swift
@@ -91,7 +91,7 @@ class VaultFormat7ProviderDecorator: CloudProvider {
 		}
 	}
 
-	func uploadFile(from cleartextLocalURL: URL, to cleartextCloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	func uploadFile(from cleartextLocalURL: URL, to cleartextCloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(cleartextLocalURL.isFileURL)
 		let overallProgress = Progress(totalUnitCount: 5)
 		let ciphertextLocalURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
@@ -103,7 +103,7 @@ class VaultFormat7ProviderDecorator: CloudProvider {
 			try self.cryptor.encryptContent(from: cleartextLocalURL, to: ciphertextLocalURL)
 			overallProgress.resignCurrent()
 			overallProgress.becomeCurrent(withPendingUnitCount: 4)
-			let uploadFilePromise = self.delegate.uploadFile(from: ciphertextLocalURL, to: ciphertextCloudPath, replaceExisting: replaceExisting)
+			let uploadFilePromise = self.delegate.uploadFile(from: ciphertextLocalURL, to: ciphertextCloudPath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 			overallProgress.resignCurrent()
 			return uploadFilePromise
 		}.recover { error -> CloudItemMetadata in

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecorator.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecorator.swift
@@ -86,20 +86,20 @@ class VaultFormat7ShorteningProviderDecorator: CloudProvider {
 		}
 	}
 
-	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		let shortened = shortenedNameCache.getShortenedPath(cloudPath)
 		if shortened.pointsToC9S, let c9sDir = shortened.c9sDir {
 			return createC9SFolderAndUploadNameFile(c9sDir).then { () -> Promise<CloudItemMetadata> in
 				let contentsFilePath = shortened.cloudPath.appendingContentsFileComponent()
-				return self.delegate.uploadFile(from: localURL, to: contentsFilePath, replaceExisting: replaceExisting)
+				return self.delegate.uploadFile(from: localURL, to: contentsFilePath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 			}.then { _ in
 				return self.delegate.fetchItemMetadata(at: shortened.cloudPath)
 			}.then { shortenedMetadata in
 				return self.getOriginalMetadata(shortenedMetadata)
 			}
 		} else {
-			return delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting)
+			return delegate.uploadFile(from: localURL, to: shortened.cloudPath, replaceExisting: replaceExisting, onTaskCreation: onTaskCreation)
 		}
 	}
 

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
@@ -80,7 +80,7 @@ public class DropboxCloudProvider: CloudProvider {
 	/**
 	 - Warning: This function is not atomic, because the existence of the parent folder is checked first, otherwise Dropbox creates the missing folders automatically.
 	 */
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		guard let authorizedClient = credential.authorizedClient else {
 			return Promise(CloudProviderError.unauthorized)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -113,7 +113,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		var isDirectory: ObjCBool = false
 		let fileExists = FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDirectory)

--- a/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
+++ b/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
@@ -216,7 +216,7 @@ public class LocalFileSystemProvider: CloudProvider {
 		return promise
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		let url = rootURL.appendingPathComponent(cloudPath)
 		let shouldStopAccessing = url.startAccessingSecurityScopedResource()

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -69,7 +69,7 @@ public class OneDriveCloudProvider: CloudProvider {
 		}
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		let attributes: [FileAttributeKey: Any]
 		do {

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCloudProvider.swift
@@ -44,7 +44,7 @@ public class PCloudCloudProvider: CloudProvider {
 		}
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		var isDirectory: ObjCBool = false
 		let fileExists = FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDirectory)

--- a/Sources/CryptomatorCloudAccess/S3/S3CloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/S3/S3CloudProvider.swift
@@ -129,7 +129,7 @@ public class S3CloudProvider: CloudProvider {
 		}
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		CloudAccessDDLogDebug("S3CloudProvider: uploadFile(from: \(localURL), to: \(cloudPath.path), replaceExisting: \(replaceExisting)) called")
 		var isDirectory: ObjCBool = false
 		let fileExists = FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDirectory)

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
@@ -89,10 +89,10 @@ public class WebDAVClient {
 		return webDAVSession.performDownloadTask(with: request, to: localURL, onTaskCreation: onTaskCreation)
 	}
 
-	public func PUT(url: URL, fileURL: URL) -> Promise<(HTTPURLResponse, Data?)> {
+	public func PUT(url: URL, fileURL: URL, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<(HTTPURLResponse, Data?)> {
 		var request = URLRequest(url: url)
 		request.httpMethod = "PUT"
-		return webDAVSession.performUploadTask(with: request, fromFile: fileURL)
+		return webDAVSession.performUploadTask(with: request, fromFile: fileURL, onTaskCreation: onTaskCreation)
 	}
 
 	public func MKCOL(url: URL) -> Promise<(HTTPURLResponse, Data?)> {

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
@@ -142,7 +142,7 @@ public class WebDAVProvider: CloudProvider {
 	}
 
 	// swiftlint:disable:next cyclomatic_complexity
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		guard let url = URL(cloudPath: cloudPath, relativeTo: client.baseURL) else {
 			return Promise(WebDAVProviderError.resolvingURLFailed)

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVProvider.swift
@@ -163,7 +163,7 @@ public class WebDAVProvider: CloudProvider {
 			}
 		}.then { _ -> Promise<(HTTPURLResponse, Data?)> in
 			progress.becomeCurrent(withPendingUnitCount: 1)
-			let putPromise = self.client.PUT(url: url, fileURL: localURL)
+			let putPromise = self.client.PUT(url: url, fileURL: localURL, onTaskCreation: onTaskCreation)
 			progress.resignCurrent()
 			return putPromise
 		}.recover { error -> Promise<(HTTPURLResponse, Data?)> in

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
@@ -233,7 +233,7 @@ class WebDAVSession {
 		}
 	}
 
-	func performUploadTask(with request: URLRequest, fromFile fileURL: URL) -> Promise<(HTTPURLResponse, Data?)> {
+	func performUploadTask(with request: URLRequest, fromFile fileURL: URL, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<(HTTPURLResponse, Data?)> {
 		HTTPDebugLogger.logRequest(request)
 		let progress = Progress(totalUnitCount: 1)
 		let task = urlSession.uploadTask(with: request, fromFile: fileURL)
@@ -241,6 +241,7 @@ class WebDAVSession {
 		let pendingPromise = Promise<(HTTPURLResponse, Data?)>.pending()
 		let webDAVDataTask = WebDAVDataTask(promise: pendingPromise)
 		delegate?.addRunningDataTask(key: task, value: webDAVDataTask)
+		onTaskCreation?(task)
 		task.resume()
 		return pendingPromise.then { response, data -> Promise<(HTTPURLResponse, Data?)> in
 			HTTPDebugLogger.logResponse(response, with: data, or: nil)

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
@@ -237,11 +237,11 @@ class WebDAVSession {
 		HTTPDebugLogger.logRequest(request)
 		let progress = Progress(totalUnitCount: 1)
 		let task = urlSession.uploadTask(with: request, fromFile: fileURL)
+		onTaskCreation?(task)
 		progress.addChild(task.progress, withPendingUnitCount: 1)
 		let pendingPromise = Promise<(HTTPURLResponse, Data?)>.pending()
 		let webDAVDataTask = WebDAVDataTask(promise: pendingPromise)
 		delegate?.addRunningDataTask(key: task, value: webDAVDataTask)
-		onTaskCreation?(task)
 		task.resume()
 		return pendingPromise.then { response, data -> Promise<(HTTPURLResponse, Data?)> in
 			HTTPDebugLogger.logResponse(response, with: data, or: nil)

--- a/Tests/CryptomatorCloudAccessTests/API/CloudProvider+ConvenienceTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/API/CloudProvider+ConvenienceTests.swift
@@ -208,7 +208,7 @@ private class ConvenienceCloudProviderMock: CloudProvider {
 		return Promise(CloudProviderError.noInternetConnection)
 	}
 
-	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		return Promise(CloudProviderError.noInternetConnection)
 	}
 

--- a/Tests/CryptomatorCloudAccessTests/Crypto/CloudProviderMock.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/CloudProviderMock.swift
@@ -65,7 +65,7 @@ public class CloudProviderMock: CloudProvider {
 		}
 	}
 
-	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool) -> Promise<CloudItemMetadata> {
+	public func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
 		precondition(localURL.isFileURL)
 		do {
 			let data = try Data(contentsOf: localURL)

--- a/Tests/CryptomatorCloudAccessTests/WebDAV/WebDAVClientMock.swift
+++ b/Tests/CryptomatorCloudAccessTests/WebDAV/WebDAVClientMock.swift
@@ -58,9 +58,9 @@ class WebDAVClientMock: WebDAVClient {
 		return super.GET(from: url, to: localURL, onTaskCreation: onTaskCreation)
 	}
 
-	override func PUT(url: URL, fileURL: URL) -> Promise<(HTTPURLResponse, Data?)> {
+	override func PUT(url: URL, fileURL: URL, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<(HTTPURLResponse, Data?)> {
 		putRequests.append(url.relativePath)
-		return super.PUT(url: url, fileURL: fileURL)
+		return super.PUT(url: url, fileURL: fileURL, onTaskCreation: onTaskCreation)
 	}
 
 	override func MKCOL(url: URL) -> Promise<(HTTPURLResponse, Data?)> {


### PR DESCRIPTION
Changes the CloudProvider API to return an optional `URLSessionUploadTask` on task creation.

Rationale:

The FileProviderExtension only reports the upload progress when we actually register a real URLSessionTask via NSFileProviderManager.register(…) ([Documentation](https://developer.apple.com/documentation/fileprovider/nsfileprovidermanager/2890932-register)).
Therefore, we need to return the `URLSessionUploadTask` via the CloudProvider as soon as this task has been created.
For now this can be tested with WebDAV. 

For some CloudProviders the `onTaskCreation` closure will never be called as they simply to not have a `URLSessionUploadTask` like the `LocalFileSystemProvider`. Unfortunately this also implies that we can not report the upload progress for iCloud Drive. Additionally we can't report the upload progress when the provider uses chunked uploads as the `FileProviderExtension` expects that the upload task corresponds to the whole file.