### PR TITLE
Log TLS certificate validation failures

### DIFF
--- a/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
@@ -50,7 +50,7 @@ private class TLSCertificateValidatorURLSessionDelegate: NSObject, URLSessionTas
 		CC_SHA256(bytes, UInt32(bytes.count) as CC_LONG, &digest)
 		return digest.toHexString(separator: " ")
 	}
-	
+
 	private func handleChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
 		if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust, let trust = challenge.protectionSpace.serverTrust, let certificate = getCertificate(from: trust) {
 			let isTrusted = SecTrustEvaluateWithError(trust, nil)

--- a/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
@@ -26,20 +26,13 @@ private class TLSCertificateValidatorURLSessionDelegate: NSObject, URLSessionTas
 	// MARK: - URLSessionDelegate
 
 	func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-		if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust, let trust = challenge.protectionSpace.serverTrust, let certificate = getCertificate(from: trust) {
-			let isTrusted = SecTrustEvaluateWithError(trust, nil)
-			let fingerprint = calculateFingerprint(from: certificate)
-			testedCertificate = TLSCertificate(data: certificate, isTrusted: isTrusted, fingerprint: fingerprint)
-		} else {
-			CloudAccessDDLogError("TLSCertificateValidator: failed to get certificate from received challenge.protectionSpace: \(challenge.protectionSpace)")
-		}
-		completionHandler(.cancelAuthenticationChallenge, nil)
+		handleChallenge(challenge, completionHandler: completionHandler)
 	}
 
 	// MARK: - URLSessionTaskDelegate
 
 	func urlSession(_ session: URLSession, task: URLSessionTask, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
-		completionHandler(.cancelAuthenticationChallenge, nil)
+		handleChallenge(challenge, completionHandler: completionHandler)
 	}
 
 	// MARK: - Internal
@@ -56,6 +49,17 @@ private class TLSCertificateValidatorURLSessionDelegate: NSObject, URLSessionTas
 		var digest = [UInt8](repeating: 0x00, count: Int(CC_SHA1_DIGEST_LENGTH))
 		CC_SHA256(bytes, UInt32(bytes.count) as CC_LONG, &digest)
 		return digest.toHexString(separator: " ")
+	}
+	
+	private func handleChallenge(_ challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+		if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust, let trust = challenge.protectionSpace.serverTrust, let certificate = getCertificate(from: trust) {
+			let isTrusted = SecTrustEvaluateWithError(trust, nil)
+			let fingerprint = calculateFingerprint(from: certificate)
+			testedCertificate = TLSCertificate(data: certificate, isTrusted: isTrusted, fingerprint: fingerprint)
+		} else {
+			CloudAccessDDLogError("TLSCertificateValidator: failed to get certificate from received challenge.protectionSpace: \(challenge.protectionSpace)")
+		}
+		completionHandler(.cancelAuthenticationChallenge, nil)
 	}
 }
 

--- a/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/TLSCertificateValidator.swift
@@ -30,6 +30,8 @@ private class TLSCertificateValidatorURLSessionDelegate: NSObject, URLSessionTas
 			let isTrusted = SecTrustEvaluateWithError(trust, nil)
 			let fingerprint = calculateFingerprint(from: certificate)
 			testedCertificate = TLSCertificate(data: certificate, isTrusted: isTrusted, fingerprint: fingerprint)
+		} else {
+			CloudAccessDDLogError("TLSCertificateValidator: failed to get certificate from received challenge.protectionSpace: \(challenge.protectionSpace)")
 		}
 		completionHandler(.cancelAuthenticationChallenge, nil)
 	}


### PR DESCRIPTION
Log when the `TLSCertificateValidators` fails to extract the certificate from the provided challenge.
Also handle the challenge for the `URLSessionTaskDelegate` implementation.
That might already fix issue https://github.com/cryptomator/ios/issues/291 or at least allows us to better debug it.