### PR TITLE
Preparations for Hub 1.3.0 support

### DIFF
--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -1759,8 +1759,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tobihagemann/JOSESwift.git";
 			requirement = {
-				kind = exactVersion;
-				version = "2.4.0-cryptomator";
+				branch = feature/cryptomator;
+				kind = branch;
 			};
 		};
 		746BE0A926579D4A00FB674E /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */ = {

--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -1759,8 +1759,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/tobihagemann/JOSESwift.git";
 			requirement = {
-				branch = feature/cryptomator;
-				kind = branch;
+				kind = exactVersion;
+				version = "2.4.1-cryptomato";
 			};
 		};
 		746BE0A926579D4A00FB674E /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */ = {

--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -1760,7 +1760,7 @@
 			repositoryURL = "https://github.com/tobihagemann/JOSESwift.git";
 			requirement = {
 				kind = exactVersion;
-				version = "2.4.1-cryptomato";
+				version = "2.4.1-cryptomator";
 			};
 		};
 		746BE0A926579D4A00FB674E /* XCRemoteSwiftPackageReference "microsoft-authentication-library-for-objc" */ = {

--- a/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tobihagemann/JOSESwift.git",
       "state" : {
-        "branch" : "feature/cryptomator",
-        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01"
+        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01",
+        "version" : "2.4.1-cryptomator"
       }
     },
     {

--- a/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tobihagemann/JOSESwift.git",
       "state" : {
-        "revision" : "11442e7f1f803ef42281909c68f386b38afc5096",
-        "version" : "2.4.0-cryptomator"
+        "branch" : "feature/cryptomator",
+        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tobihagemann/JOSESwift.git",
       "state" : {
-        "branch" : "feature/cryptomator",
-        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01"
+        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01",
+        "version" : "2.4.1-cryptomator"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/tobihagemann/JOSESwift.git",
       "state" : {
-        "revision" : "11442e7f1f803ef42281909c68f386b38afc5096",
-        "version" : "2.4.0-cryptomator"
+        "branch" : "feature/cryptomator",
+        "revision" : "3544f8117908ef12ea13b1c0927e0e3c0d30ee01"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
 		.library(name: "CryptomatorCloudAccessCore", targets: ["CryptomatorCloudAccessCore"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/tobihagemann/JOSESwift.git", branch: "feature/cryptomator"),
+		.package(url: "https://github.com/tobihagemann/JOSESwift.git", exact: "2.4.1-cryptomator"),
 		.package(url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git", .upToNextMinor(from: "1.2.0")),
 		.package(url: "https://github.com/aws-amplify/aws-sdk-ios-spm.git", .upToNextMinor(from: "2.33.0")),
 		.package(url: "https://github.com/cryptomator/cryptolib-swift.git", .upToNextMinor(from: "1.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
 		.library(name: "CryptomatorCloudAccessCore", targets: ["CryptomatorCloudAccessCore"])
 	],
 	dependencies: [
-		.package(url: "https://github.com/tobihagemann/JOSESwift.git", exact: "2.4.0-cryptomator"),
+        .package(url: "https://github.com/tobihagemann/JOSESwift.git", branch: "feature/cryptomator"),
 		.package(url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git", .upToNextMinor(from: "1.2.0")),
 		.package(url: "https://github.com/aws-amplify/aws-sdk-ios-spm.git", .upToNextMinor(from: "2.33.0")),
 		.package(url: "https://github.com/cryptomator/cryptolib-swift.git", .upToNextMinor(from: "1.1.0")),

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
 		.library(name: "CryptomatorCloudAccessCore", targets: ["CryptomatorCloudAccessCore"])
 	],
 	dependencies: [
-        .package(url: "https://github.com/tobihagemann/JOSESwift.git", branch: "feature/cryptomator"),
+		.package(url: "https://github.com/tobihagemann/JOSESwift.git", branch: "feature/cryptomator"),
 		.package(url: "https://github.com/AzureAD/microsoft-authentication-library-for-objc.git", .upToNextMinor(from: "1.2.0")),
 		.package(url: "https://github.com/aws-amplify/aws-sdk-ios-spm.git", .upToNextMinor(from: "2.33.0")),
 		.package(url: "https://github.com/cryptomator/cryptolib-swift.git", .upToNextMinor(from: "1.1.0")),

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultConfig.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultConfig.swift
@@ -34,21 +34,23 @@ struct VaultConfigPayload: Equatable, Codable {
 }
 
 public struct HubConfig: Equatable, Codable {
-	public init(clientId: String, authEndpoint: String, tokenEndpoint: String, devicesResourceUrl: String, authSuccessUrl: String, authErrorUrl: String) {
-		self.clientId = clientId
-		self.authEndpoint = authEndpoint
-		self.tokenEndpoint = tokenEndpoint
-		self.devicesResourceUrl = devicesResourceUrl
-		self.authSuccessUrl = authSuccessUrl
-		self.authErrorUrl = authErrorUrl
-	}
-
 	public let clientId: String
 	public let authEndpoint: String
 	public let tokenEndpoint: String
-	public let devicesResourceUrl: String
 	public let authSuccessUrl: String
 	public let authErrorUrl: String
+	public let apiBaseUrl: String?
+	public let devicesResourceUrl: String
+
+	public init(clientId: String, authEndpoint: String, tokenEndpoint: String, authSuccessUrl: String, authErrorUrl: String, apiBaseUrl: String?, devicesResourceUrl: String) {
+		self.clientId = clientId
+		self.authEndpoint = authEndpoint
+		self.tokenEndpoint = tokenEndpoint
+		self.authSuccessUrl = authSuccessUrl
+		self.authErrorUrl = authErrorUrl
+		self.apiBaseUrl = apiBaseUrl
+		self.devicesResourceUrl = devicesResourceUrl
+	}
 }
 
 public class UnverifiedVaultConfig {

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/DecoratorFactory.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/DecoratorFactory.swift
@@ -15,7 +15,7 @@ import Promises
 #endif
 @testable import CryptomatorCryptoLib
 
-class DecoratorFactory {
+enum DecoratorFactory {
 	// MARK: - Vault Format 7
 
 	static func createNewVaultFormat7(delegate: CloudProvider, vaultPath: CloudPath, password: String) -> Promise<VaultFormat7ProviderDecorator> {

--- a/Tests/CryptomatorCloudAccessIntegrationTests/Google Drive/GoogleDriveAuthenticatorMock.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/Google Drive/GoogleDriveAuthenticatorMock.swift
@@ -16,7 +16,7 @@ import CryptomatorCloudAccessCore
 import CryptomatorCloudAccess
 #endif
 
-class GoogleDriveAuthenticatorMock {
+enum GoogleDriveAuthenticatorMock {
 	static func generateAuthorizedCredential(withRefreshToken refreshToken: String, tokenUID: String) -> GoogleDriveCredential {
 		let authorizationEndpoint = URL(string: "https://accounts.google.com/o/oauth2/v2/auth")!
 		let tokenEndPoint = URL(string: "https://oauth2.googleapis.com/token")!


### PR DESCRIPTION
Prepares `cloud-access-swift` to support Cryptomator Hub 1.3.0 in the main app.
In particular:
- update the HubConfig to include the new property `apiBaseUrl`
- use a newer version of our JOSESwift fork which adds the support for `PBES2-HS512+A256KW` which is needed in the updated device registration flow

We should create a new release of `cloud-access-swift` after this has been merged.

