### PR TITLE
CI Update: Use macOS 14 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,23 +6,27 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       DERIVED_DATA_PATH: 'DerivedData'
-      DEVICE: 'iPhone 12 Pro'
+      DEVICE: 'iPhone 15 Pro'
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
+      - name: Install SwiftLint
+        run: brew install swiftlint
       - name: Run process.sh script
         run: |
           ./Scripts/process.sh
           exit $?
+      - name: Select Xcode 15.2
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'CryptomatorCloudAccess' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH -enableCodeCoverage YES | xcpretty
       - name: Test
@@ -59,11 +63,11 @@ jobs:
 
   release:
     name: Deploy and draft a release
-    runs-on: macos-12
+    runs-on: macos-14
     needs: build
     if: startsWith(github.ref, 'refs/tags/')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Draft release
         uses: actions/create-release@v1
         env:

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxSetup.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxSetup.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+
 /**
  Setup for the Dropbox Cloud Provider
 


### PR DESCRIPTION
On January 30, 2024, Github [introduced](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) the macOS Sonoma image and made it possible to [use M1 macOS Runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source).

As before the runner is available for free in public repositories:
> This runner is available for all plans, free in public repositories, and eligible to consume included free plan minutes in private repositories.

In addition I've did minor upgrades to the used actions:
- bumped `actions/checkout` to `v4`
- bumped `actions/cache` to `v4`

Explicitly set the used Xcode version to `15.2`.

The only downside is that the new arm64 based image does not have SwiftLint pre-installed therefore I've added an additional step.

Basically the same as with: https://github.com/cryptomator/ios/pull/339

The only difference is that I needed to fix a SwiftFormat linter warning because otherwise the CI would not pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the macOS version to 14 for build and release processes.
	- Updated GitHub actions for checkout and cache to version 4.
	- Added SwiftLint installation and configured Xcode 15.2 for the build environment.

- **New Features**
	- Enhanced Dropbox integration in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->