### PR TITLE
Remove "immediatelyAvailableMetadataOnly" from "getItemMetadata"

### DIFF
--- a/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
+++ b/Sources/CryptomatorCloudAccess/LocalFileSystem/LocalFileSystemProvider.swift
@@ -458,7 +458,7 @@ public class LocalFileSystemProvider: CloudProvider {
 	private func getItemMetadata(forItemAt url: URL, parentCloudPath: CloudPath) -> Promise<CloudItemMetadata> {
 		CloudAccessDDLogDebug("LocalFileSystemProvider: getItemMetadata(forItemAt: \(url), parentCloudPath: \(parentCloudPath.path)) called")
 		let promise = Promise<CloudItemMetadata>.pending()
-		let readingIntent = NSFileAccessIntent.readingIntent(with: url, options: .immediatelyAvailableMetadataOnly)
+		let readingIntent = NSFileAccessIntent.readingIntent(with: url)
 		fileCoordinator.coordinate(with: [readingIntent], queue: queue) { error in
 			if let error = error {
 				CloudAccessDDLogDebug("LocalFileSystemProvider: getItemMetadata(forItemAt: \(url), parentCloudPath: \(parentCloudPath.path)) failed coordinated read with error: \(error)")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved file metadata fetching to ensure more comprehensive data is retrieved without limiting to immediately available metadata.
	- Concealed internal code details for security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->