### PR TITLE
Allow the injection of background URLSession identifier

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,8 +25,8 @@ jobs:
         run: |
           ./Scripts/process.sh
           exit $?
-      - name: Select Xcode 15.2
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+      - name: Select Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
       - name: Build
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'CryptomatorCloudAccess' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH -enableCodeCoverage YES | xcpretty
       - name: Test

--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -65,6 +65,8 @@
 		4A7C214D245305BB00DE81E6 /* CloudItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7C214C245305BB00DE81E6 /* CloudItemType.swift */; };
 		4A8B872F287D7E77002D676E /* CocoaLumberjackSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 4A8B872E287D7E77002D676E /* CocoaLumberjackSwift */; };
 		4A8B8734287D8036002D676E /* CloudAccessDDLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8B8733287D8036002D676E /* CloudAccessDDLog.swift */; };
+		4ABE9AA32BCAC8FE00675D74 /* Promise+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABE9AA22BCAC8FE00675D74 /* Promise+Async.swift */; };
+		4ABE9AA62BCACD1300675D74 /* XCTAssertThrowsError+Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABE9AA42BCACB9100675D74 /* XCTAssertThrowsError+Async.swift */; };
 		4AC75F9028607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC75F8F28607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift */; };
 		4AC75F9A2861A425002731FE /* VaultFormat7S3IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC75F992861A425002731FE /* VaultFormat7S3IntegrationTests.swift */; };
 		4AC75F9C2861A6DE002731FE /* VaultFormat6S3IntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC75F9B2861A6DE002731FE /* VaultFormat6S3IntegrationTests.swift */; };
@@ -256,6 +258,8 @@
 		4A77390C286DB5A00006B3C3 /* AWSS3TransferUtility+ForegroundSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AWSS3TransferUtility+ForegroundSession.swift"; sourceTree = "<group>"; };
 		4A7C214C245305BB00DE81E6 /* CloudItemType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudItemType.swift; sourceTree = "<group>"; };
 		4A8B8733287D8036002D676E /* CloudAccessDDLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudAccessDDLog.swift; sourceTree = "<group>"; };
+		4ABE9AA22BCAC8FE00675D74 /* Promise+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Promise+Async.swift"; sourceTree = "<group>"; };
+		4ABE9AA42BCACB9100675D74 /* XCTAssertThrowsError+Async.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTAssertThrowsError+Async.swift"; sourceTree = "<group>"; };
 		4AC75F8F28607B20002731FE /* CustomAWSEndpointRegionNameStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAWSEndpointRegionNameStorage.swift; sourceTree = "<group>"; };
 		4AC75F992861A425002731FE /* VaultFormat7S3IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat7S3IntegrationTests.swift; sourceTree = "<group>"; };
 		4AC75F9B2861A6DE002731FE /* VaultFormat6S3IntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultFormat6S3IntegrationTests.swift; sourceTree = "<group>"; };
@@ -465,6 +469,7 @@
 				7402B48227D2625E00BE9F8B /* PCloud */,
 				4A2745FA2847887F00E70D5F /* S3 */,
 				748420C124B8A1F800D84E58 /* WebDAV */,
+				4ABE9AA42BCACB9100675D74 /* XCTAssertThrowsError+Async.swift */,
 			);
 			path = CryptomatorCloudAccessTests;
 			sourceTree = "<group>";
@@ -566,6 +571,7 @@
 			isa = PBXGroup;
 			children = (
 				4A765CA22878596000794440 /* DirectoryContentCache.swift */,
+				4ABE9AA22BCAC8FE00675D74 /* Promise+Async.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -1233,6 +1239,7 @@
 				9E969456249B8493000DB743 /* VaultFormat7ShortenedNameCache.swift in Sources */,
 				7471BDAE24865B6F000D05FC /* LocalFileSystemProvider.swift in Sources */,
 				7484608729795421009933D8 /* VaultConfigHelper.swift in Sources */,
+				4ABE9AA32BCAC8FE00675D74 /* Promise+Async.swift in Sources */,
 				74073D1927C9406000A86C9A /* Task+Promises.swift in Sources */,
 				4A1A1194262EC46E00DAF62F /* OneDriveIdentifierCache.swift in Sources */,
 				746F091327BC0DA2003FCD9F /* PCloudCredential.swift in Sources */,
@@ -1313,6 +1320,7 @@
 				4A741FF5287C98F300489C23 /* DirectoryContentCacheMock.swift in Sources */,
 				7494505F24BC5C3300149816 /* PropfindResponseParserTests.swift in Sources */,
 				4A6D2CD62643EE83006C5574 /* VaultProviderFactoryTests.swift in Sources */,
+				4ABE9AA62BCACD1300675D74 /* XCTAssertThrowsError+Async.swift in Sources */,
 				4A30DAF62636D79C004B5B4E /* OneDriveCloudProviderTests.swift in Sources */,
 				9EE62A10247D54E90089DAF7 /* CloudProvider+ConvenienceTests.swift in Sources */,
 				74E32BEA283E575B005D8A54 /* VaultFormat8CryptorMock.swift in Sources */,

--- a/Sources/CryptomatorCloudAccess/Common/Promise+Async.swift
+++ b/Sources/CryptomatorCloudAccess/Common/Promise+Async.swift
@@ -1,0 +1,14 @@
+import Foundation
+import Promises
+
+extension Promise {
+    func async() async throws -> Value {
+        try await withCheckedThrowingContinuation { continuation in
+            then { value in
+                continuation.resume(returning: value)
+            }.catch { error in
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}

--- a/Sources/CryptomatorCloudAccess/Common/Promise+Async.swift
+++ b/Sources/CryptomatorCloudAccess/Common/Promise+Async.swift
@@ -2,13 +2,13 @@ import Foundation
 import Promises
 
 extension Promise {
-    func async() async throws -> Value {
-        try await withCheckedThrowingContinuation { continuation in
-            then { value in
-                continuation.resume(returning: value)
-            }.catch { error in
-                continuation.resume(throwing: error)
-            }
-        }
-    }
+	func async() async throws -> Value {
+		try await withCheckedThrowingContinuation { continuation in
+			then { value in
+				continuation.resume(returning: value)
+			}.catch { error in
+				continuation.resume(throwing: error)
+			}
+		}
+	}
 }

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -14,9 +14,9 @@ import Promises
 
 public class GoogleDriveCloudProvider: CloudProvider {
 	private static let maximumUploadFetcherChunkSize: UInt = 3 * 1024 * 1024 // 3MiB per chunk as GTMSessionFetcher loads the chunk to the memory and the FileProviderExtension has a total memory limit of 15MB
-    public enum Constants {
-       public static var maxPageSize: Int { 1000 }
-    }
+	public enum Constants {
+		public static var maxPageSize: Int { 1000 }
+	}
 
 	private let driveService: GTLRDriveService
 	private let identifierCache: GoogleDriveIdentifierCache
@@ -25,34 +25,34 @@ public class GoogleDriveCloudProvider: CloudProvider {
 	private var runningFetchers: [GTMSessionFetcher]
 	private let maxPageSize: Int
 
-    init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize, urlSessionConfiguration: URLSessionConfiguration) throws {
+	init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize, urlSessionConfiguration: URLSessionConfiguration) throws {
 		self.driveService = credential.driveService
 		self.identifierCache = try GoogleDriveIdentifierCache()
 		self.runningTickets = [GTLRServiceTicket]()
 		self.runningFetchers = [GTMSessionFetcher]()
 		let maxAllowedItemLimit = 1000
 		self.maxPageSize = min(max(1, maxPageSize), maxAllowedItemLimit)
-        try setupDriveService(credential: credential, configuration: urlSessionConfiguration)
+		try setupDriveService(credential: credential, configuration: urlSessionConfiguration)
 	}
-    
-    public convenience init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize) throws {
-        try self.init(
-            credential: credential,
-            maxPageSize: maxPageSize,
-            urlSessionConfiguration: .default
-        )
-    }
-    
-    public static func withBackgroundSession(
-        credential: GoogleDriveCredential,
-        maxPageSize: Int = Constants.maxPageSize,
-        sessionIdentifier: String,
-        sharedContainerIdentifier: String? = nil
-    ) throws -> GoogleDriveCloudProvider {
-        let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
-        configuration.sharedContainerIdentifier = sharedContainerIdentifier
-        return try .init(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: configuration)
-    }
+
+	public convenience init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize) throws {
+		try self.init(
+			credential: credential,
+			maxPageSize: maxPageSize,
+			urlSessionConfiguration: .default
+		)
+	}
+
+	public static func withBackgroundSession(
+		credential: GoogleDriveCredential,
+		maxPageSize: Int = Constants.maxPageSize,
+		sessionIdentifier: String,
+		sharedContainerIdentifier: String? = nil
+	) throws -> GoogleDriveCloudProvider {
+		let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
+		configuration.sharedContainerIdentifier = sharedContainerIdentifier
+		return try .init(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: configuration)
+	}
 
 	private func setupDriveService(credential: GoogleDriveCredential, configuration: URLSessionConfiguration) throws {
 		driveService.serviceUploadChunkSize = GoogleDriveCloudProvider.maximumUploadFetcherChunkSize
@@ -74,11 +74,11 @@ public class GoogleDriveCloudProvider: CloudProvider {
 			return suggestedWillRetry
 		}
 
-        driveService.fetcherService.configurationBlock = { _, configurationToConfigure in
-            configurationToConfigure.sharedContainerIdentifier = configuration.sharedContainerIdentifier
-        }
+		driveService.fetcherService.configurationBlock = { _, configurationToConfigure in
+			configurationToConfigure.sharedContainerIdentifier = configuration.sharedContainerIdentifier
+		}
 		driveService.fetcherService.configuration = configuration
-        
+
 		driveService.fetcherService.isRetryEnabled = true
 		driveService.fetcherService.retryBlock = { suggestedWillRetry, error, response in
 			if let error = error as NSError? {

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -14,9 +14,6 @@ import Promises
 
 public class GoogleDriveCloudProvider: CloudProvider {
 	private static let maximumUploadFetcherChunkSize: UInt = 3 * 1024 * 1024 // 3MiB per chunk as GTMSessionFetcher loads the chunk to the memory and the FileProviderExtension has a total memory limit of 15MB
-	public enum Constants {
-		public static var maxPageSize: Int { 1000 }
-	}
 
 	private let driveService: GTLRDriveService
 	private let identifierCache: GoogleDriveIdentifierCache
@@ -25,7 +22,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 	private var runningFetchers: [GTMSessionFetcher]
 	private let maxPageSize: Int
 
-	init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize, urlSessionConfiguration: URLSessionConfiguration) throws {
+	init(credential: GoogleDriveCredential, maxPageSize: Int = .max, urlSessionConfiguration: URLSessionConfiguration) throws {
 		self.driveService = credential.driveService
 		self.identifierCache = try GoogleDriveIdentifierCache()
 		self.runningTickets = [GTLRServiceTicket]()
@@ -35,20 +32,11 @@ public class GoogleDriveCloudProvider: CloudProvider {
 		try setupDriveService(credential: credential, configuration: urlSessionConfiguration)
 	}
 
-	public convenience init(credential: GoogleDriveCredential, maxPageSize: Int = Constants.maxPageSize) throws {
-		try self.init(
-			credential: credential,
-			maxPageSize: maxPageSize,
-			urlSessionConfiguration: .default
-		)
+	public convenience init(credential: GoogleDriveCredential, maxPageSize: Int = .max) throws {
+		try self.init(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: .default)
 	}
 
-	public static func withBackgroundSession(
-		credential: GoogleDriveCredential,
-		maxPageSize: Int = Constants.maxPageSize,
-		sessionIdentifier: String,
-		sharedContainerIdentifier: String? = nil
-	) throws -> GoogleDriveCloudProvider {
+	public static func withBackgroundSession(credential: GoogleDriveCredential, maxPageSize: Int = .max, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) throws -> GoogleDriveCloudProvider {
 		let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
 		configuration.sharedContainerIdentifier = sharedContainerIdentifier
 		return try .init(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: configuration)

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -19,31 +19,31 @@ public class OneDriveCloudProvider: CloudProvider {
 	private let tmpDirURL: URL
 	private let maxPageSize: Int
 
-    init(credential: OneDriveCredential, maxPageSize: Int = .max, urlSessionConfiguration: URLSessionConfiguration) throws {
+	init(credential: OneDriveCredential, maxPageSize: Int = .max, urlSessionConfiguration: URLSessionConfiguration) throws {
 		self.client = MSClientFactory.createHTTPClient(with: credential.authProvider, andSessionConfiguration: urlSessionConfiguration)
 		self.identifierCache = try OneDriveIdentifierCache()
 		self.tmpDirURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
 		self.maxPageSize = min(max(1, maxPageSize), 1000)
 		try FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
 	}
-    
-    public convenience init(credential: OneDriveCredential, maxPageSize: Int = .max) throws {
-        try self.init(
-            credential: credential,
-            maxPageSize: maxPageSize,
-            urlSessionConfiguration: .default
-        )
-    }
-    
-    public static func withBackgroundSession(credential: OneDriveCredential, maxPageSize: Int = .max, identifier: String) throws -> OneDriveCloudProvider {
-        let configuration = URLSessionConfiguration.background(withIdentifier: identifier)
-        configuration.sharedContainerIdentifier = OneDriveSetup.sharedContainerIdentifier
-        return try OneDriveCloudProvider(
-            credential: credential,
-            maxPageSize: maxPageSize,
-            urlSessionConfiguration: configuration
-        )
-    }
+
+	public convenience init(credential: OneDriveCredential, maxPageSize: Int = .max) throws {
+		try self.init(
+			credential: credential,
+			maxPageSize: maxPageSize,
+			urlSessionConfiguration: .default
+		)
+	}
+
+	public static func withBackgroundSession(credential: OneDriveCredential, maxPageSize: Int = .max, identifier: String) throws -> OneDriveCloudProvider {
+		let configuration = URLSessionConfiguration.background(withIdentifier: identifier)
+		configuration.sharedContainerIdentifier = OneDriveSetup.sharedContainerIdentifier
+		return try OneDriveCloudProvider(
+			credential: credential,
+			maxPageSize: maxPageSize,
+			urlSessionConfiguration: configuration
+		)
+	}
 
 	deinit {
 		try? FileManager.default.removeItem(at: tmpDirURL)

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -19,29 +19,34 @@ public class OneDriveCloudProvider: CloudProvider {
 	private let tmpDirURL: URL
 	private let maxPageSize: Int
 
-	public init(credential: OneDriveCredential, useBackgroundSession: Bool = false, maxPageSize: Int = .max) throws {
-		let urlSessionConfiguration = OneDriveCloudProvider.createURLSessionConfiguration(credential: credential, useBackgroundSession: useBackgroundSession)
+    init(credential: OneDriveCredential, maxPageSize: Int = .max, urlSessionConfiguration: URLSessionConfiguration) throws {
 		self.client = MSClientFactory.createHTTPClient(with: credential.authProvider, andSessionConfiguration: urlSessionConfiguration)
 		self.identifierCache = try OneDriveIdentifierCache()
 		self.tmpDirURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: true)
 		self.maxPageSize = min(max(1, maxPageSize), 1000)
 		try FileManager.default.createDirectory(at: tmpDirURL, withIntermediateDirectories: true)
 	}
+    
+    public convenience init(credential: OneDriveCredential, maxPageSize: Int = .max) throws {
+        try self.init(
+            credential: credential,
+            maxPageSize: maxPageSize,
+            urlSessionConfiguration: .default
+        )
+    }
+    
+    public static func withBackgroundSession(credential: OneDriveCredential, maxPageSize: Int = .max, identifier: String) throws -> OneDriveCloudProvider {
+        let configuration = URLSessionConfiguration.background(withIdentifier: identifier)
+        configuration.sharedContainerIdentifier = OneDriveSetup.sharedContainerIdentifier
+        return try OneDriveCloudProvider(
+            credential: credential,
+            maxPageSize: maxPageSize,
+            urlSessionConfiguration: configuration
+        )
+    }
 
 	deinit {
 		try? FileManager.default.removeItem(at: tmpDirURL)
-	}
-
-	static func createURLSessionConfiguration(credential: OneDriveCredential, useBackgroundSession: Bool) -> URLSessionConfiguration {
-		let configuration: URLSessionConfiguration
-		if useBackgroundSession {
-			let bundleId = Bundle.main.bundleIdentifier ?? ""
-			configuration = URLSessionConfiguration.background(withIdentifier: "CloudAccess-OneDriveSession-\(credential.identifier)-\(bundleId)")
-			configuration.sharedContainerIdentifier = OneDriveSetup.sharedContainerIdentifier
-		} else {
-			configuration = URLSessionConfiguration.default
-		}
-		return configuration
 	}
 
 	public func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveCloudProvider.swift
@@ -28,21 +28,13 @@ public class OneDriveCloudProvider: CloudProvider {
 	}
 
 	public convenience init(credential: OneDriveCredential, maxPageSize: Int = .max) throws {
-		try self.init(
-			credential: credential,
-			maxPageSize: maxPageSize,
-			urlSessionConfiguration: .default
-		)
+		try self.init(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: .default)
 	}
 
 	public static func withBackgroundSession(credential: OneDriveCredential, maxPageSize: Int = .max, identifier: String) throws -> OneDriveCloudProvider {
 		let configuration = URLSessionConfiguration.background(withIdentifier: identifier)
 		configuration.sharedContainerIdentifier = OneDriveSetup.sharedContainerIdentifier
-		return try OneDriveCloudProvider(
-			credential: credential,
-			maxPageSize: maxPageSize,
-			urlSessionConfiguration: configuration
-		)
+		return try OneDriveCloudProvider(credential: credential, maxPageSize: maxPageSize, urlSessionConfiguration: configuration)
 	}
 
 	deinit {

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
@@ -42,12 +42,7 @@ extension PCloud {
 	 - Returns: An instance of a `PCloudClient` ready to take requests.
 	 */
 	public static func createBackgroundClient(with user: OAuth.User, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> PCloudClient {
-		return createBackgroundClient(
-			withAccessToken: user.token,
-			apiHostName: user.httpAPIHostName,
-			sessionIdentifier: sessionIdentifier,
-			sharedContainerIdentifier: sharedContainerIdentifier
-		)
+		return createBackgroundClient(withAccessToken: user.token, apiHostName: user.httpAPIHostName, sessionIdentifier: sessionIdentifier, sharedContainerIdentifier: sharedContainerIdentifier)
 	}
 
 	private static func createBackgroundClient(withAccessToken accessToken: String, apiHostName: String, sessionIdentifier: String, sharedContainerIdentifier: String?) -> PCloudClient {

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
@@ -37,17 +37,17 @@ extension PCloud {
 	 Does not update the `sharedClient` property. You are responsible for storing it and keeping it alive. Use if you want a more direct control over the lifetime of the `PCloudClient` object. Multiple clients can exist simultaneously.
 
 	 - Parameter user: A `OAuth.User` value obtained from the keychain or the OAuth flow.
-     - Parameter sessionIdentifier: The unique identifier for the `URLSessionConfiguration` object.
+	 - Parameter sessionIdentifier: The unique identifier for the `URLSessionConfiguration` object.
 	 - Parameter sharedContainerIdentifier: To create a URL session for use by an app extension, set this property to a valid identifier for a container shared between the app extension and its containing app.
 	 - Returns: An instance of a `PCloudClient` ready to take requests.
 	 */
 	public static func createBackgroundClient(with user: OAuth.User, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> PCloudClient {
-        return createBackgroundClient(
-            withAccessToken: user.token,
-            apiHostName: user.httpAPIHostName,
-            sessionIdentifier: sessionIdentifier,
-            sharedContainerIdentifier: sharedContainerIdentifier
-        )
+		return createBackgroundClient(
+			withAccessToken: user.token,
+			apiHostName: user.httpAPIHostName,
+			sessionIdentifier: sessionIdentifier,
+			sharedContainerIdentifier: sharedContainerIdentifier
+		)
 	}
 
 	private static func createBackgroundClient(withAccessToken accessToken: String, apiHostName: String, sessionIdentifier: String, sharedContainerIdentifier: String?) -> PCloudClient {

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudCredential.swift
@@ -37,12 +37,17 @@ extension PCloud {
 	 Does not update the `sharedClient` property. You are responsible for storing it and keeping it alive. Use if you want a more direct control over the lifetime of the `PCloudClient` object. Multiple clients can exist simultaneously.
 
 	 - Parameter user: A `OAuth.User` value obtained from the keychain or the OAuth flow.
+     - Parameter sessionIdentifier: The unique identifier for the `URLSessionConfiguration` object.
 	 - Parameter sharedContainerIdentifier: To create a URL session for use by an app extension, set this property to a valid identifier for a container shared between the app extension and its containing app.
 	 - Returns: An instance of a `PCloudClient` ready to take requests.
 	 */
-	public static func createBackgroundClient(with user: OAuth.User, sharedContainerIdentifier: String? = nil) -> PCloudClient {
-		let bundleId = Bundle.main.bundleIdentifier ?? ""
-		return createBackgroundClient(withAccessToken: user.token, apiHostName: user.httpAPIHostName, sessionIdentifier: "pCloud - \(user.id) - \(bundleId)", sharedContainerIdentifier: sharedContainerIdentifier)
+	public static func createBackgroundClient(with user: OAuth.User, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> PCloudClient {
+        return createBackgroundClient(
+            withAccessToken: user.token,
+            apiHostName: user.httpAPIHostName,
+            sessionIdentifier: sessionIdentifier,
+            sharedContainerIdentifier: sharedContainerIdentifier
+        )
 	}
 
 	private static func createBackgroundClient(withAccessToken accessToken: String, apiHostName: String, sessionIdentifier: String, sharedContainerIdentifier: String?) -> PCloudClient {

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
@@ -32,9 +32,9 @@ public class WebDAVClient {
 
 	 If the `WebDAVClient` is used in an app extension, set the `sharedContainerIdentifier` to a valid identifier for a container that will be shared between the app and the extension.
 	 */
-	public static func withBackgroundSession(credential: WebDAVCredential, sharedContainerIdentifier: String? = nil) -> WebDAVClient {
+    public static func withBackgroundSession(credential: WebDAVCredential, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVClient {
 		let urlSessionDelegate = WebDAVClientURLSessionDelegate(credential: credential)
-		let session = WebDAVSession.createBackgroundSession(with: urlSessionDelegate, sharedContainerIdentifier: sharedContainerIdentifier)
+        let session = WebDAVSession.createBackgroundSession(with: urlSessionDelegate, sessionIdentifier: sessionIdentifier, sharedContainerIdentifier: sharedContainerIdentifier)
 		return WebDAVClient(credential: credential, session: session)
 	}
 

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVClient.swift
@@ -32,9 +32,9 @@ public class WebDAVClient {
 
 	 If the `WebDAVClient` is used in an app extension, set the `sharedContainerIdentifier` to a valid identifier for a container that will be shared between the app and the extension.
 	 */
-    public static func withBackgroundSession(credential: WebDAVCredential, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVClient {
+	public static func withBackgroundSession(credential: WebDAVCredential, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVClient {
 		let urlSessionDelegate = WebDAVClientURLSessionDelegate(credential: credential)
-        let session = WebDAVSession.createBackgroundSession(with: urlSessionDelegate, sessionIdentifier: sessionIdentifier, sharedContainerIdentifier: sharedContainerIdentifier)
+		let session = WebDAVSession.createBackgroundSession(with: urlSessionDelegate, sessionIdentifier: sessionIdentifier, sharedContainerIdentifier: sharedContainerIdentifier)
 		return WebDAVClient(credential: credential, session: session)
 	}
 

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
@@ -186,7 +186,7 @@ class WebDAVSession {
 
 	 To avoid collisions in the `URLSession` Identifier between multiple targets (e.g. main app and app extension), the `BundleID` is used in addition to the Credential UID.
 	 */
-    static func createBackgroundSession(with delegate: WebDAVClientURLSessionDelegate, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVSession {
+	static func createBackgroundSession(with delegate: WebDAVClientURLSessionDelegate, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVSession {
 		let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
 		configuration.sharedContainerIdentifier = sharedContainerIdentifier
 		configuration.httpCookieStorage = HTTPCookieStorage()

--- a/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
+++ b/Sources/CryptomatorCloudAccess/WebDAV/WebDAVSession.swift
@@ -186,9 +186,8 @@ class WebDAVSession {
 
 	 To avoid collisions in the `URLSession` Identifier between multiple targets (e.g. main app and app extension), the `BundleID` is used in addition to the Credential UID.
 	 */
-	static func createBackgroundSession(with delegate: WebDAVClientURLSessionDelegate, sharedContainerIdentifier: String? = nil) -> WebDAVSession {
-		let bundleId = Bundle.main.bundleIdentifier ?? ""
-		let configuration = URLSessionConfiguration.background(withIdentifier: "CloudAccessWebDAVSession_\(delegate.credential.identifier)_\(bundleId)")
+    static func createBackgroundSession(with delegate: WebDAVClientURLSessionDelegate, sessionIdentifier: String, sharedContainerIdentifier: String? = nil) -> WebDAVSession {
+		let configuration = URLSessionConfiguration.background(withIdentifier: sessionIdentifier)
 		configuration.sharedContainerIdentifier = sharedContainerIdentifier
 		configuration.httpCookieStorage = HTTPCookieStorage()
 		configuration.urlCredentialStorage = nil

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6GoogleDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6GoogleDriveIntegrationTests.swift
@@ -21,7 +21,7 @@ class VaultFormat6GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 
 	private static let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: "IntegrationTest")
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	private static let cloudProvider = try! GoogleDriveCloudProvider(credential: credential)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat6")
 
 	override class func setUp() {
@@ -45,7 +45,7 @@ class VaultFormat6GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: UUID().uuidString)
-		let cloudProvider = try GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		let cloudProvider = try GoogleDriveCloudProvider(credential: credential)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat6(delegate: cloudProvider, vaultPath: VaultFormat6GoogleDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator
 		}
@@ -60,7 +60,6 @@ class VaultFormat6GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: UUID().uuidString)
 		let cloudProvider = try GoogleDriveCloudProvider(credential: credential,
-		                                                 useBackgroundSession: false,
 		                                                 maxPageSize: maxPageSizeForLimitedCloudProvider)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat6(delegate: cloudProvider, vaultPath: VaultFormat6GoogleDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6OneDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat6/VaultFormat6OneDriveIntegrationTests.swift
@@ -22,7 +22,7 @@ class VaultFormat6OneDriveIntegrationTests: CloudAccessIntegrationTest {
 	// swiftlint:disable:next force_try
 	private static let credential = try! OneDriveCredentialMock()
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	private static let cloudProvider = try! OneDriveCloudProvider(credential: credential)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat6")
 
 	override class func setUp() {
@@ -58,7 +58,6 @@ class VaultFormat6OneDriveIntegrationTests: CloudAccessIntegrationTest {
 
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		let limitedDelegate = try OneDriveCloudProvider(credential: VaultFormat6OneDriveIntegrationTests.credential,
-		                                                useBackgroundSession: false,
 		                                                maxPageSize: maxPageSizeForLimitedCloudProvider)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat6(delegate: limitedDelegate, vaultPath: VaultFormat6OneDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7GoogleDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7GoogleDriveIntegrationTests.swift
@@ -21,7 +21,7 @@ class VaultFormat7GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 
 	private static let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: "IntegrationTest")
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	private static let cloudProvider = try! GoogleDriveCloudProvider(credential: credential)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat7")
 
 	override class func setUp() {
@@ -45,7 +45,7 @@ class VaultFormat7GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: UUID().uuidString)
-		let cloudProvider = try GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		let cloudProvider = try GoogleDriveCloudProvider(credential: credential)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat7(delegate: cloudProvider, vaultPath: VaultFormat7GoogleDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator
 		}
@@ -60,7 +60,6 @@ class VaultFormat7GoogleDriveIntegrationTests: CloudAccessIntegrationTest {
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: UUID().uuidString)
 		let limitedDelegate = try GoogleDriveCloudProvider(credential: credential,
-		                                                   useBackgroundSession: false,
 		                                                   maxPageSize: maxPageSizeForLimitedCloudProvider)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat7(delegate: limitedDelegate, vaultPath: VaultFormat7GoogleDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator

--- a/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7OneDriveIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/CryptoDecorator/VaultFormat7/VaultFormat7OneDriveIntegrationTests.swift
@@ -22,7 +22,7 @@ class VaultFormat7OneDriveIntegrationTests: CloudAccessIntegrationTest {
 	// swiftlint:disable:next force_try
 	private static let credential = try! OneDriveCredentialMock()
 	// swiftlint:disable:next force_try
-	private static let cloudProvider = try! OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+	private static let cloudProvider = try! OneDriveCloudProvider(credential: credential)
 	private static let vaultPath = CloudPath("/iOS-IntegrationTests-VaultFormat7")
 
 	override class func setUp() {
@@ -58,7 +58,6 @@ class VaultFormat7OneDriveIntegrationTests: CloudAccessIntegrationTest {
 
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		let limitedDelegate = try OneDriveCloudProvider(credential: VaultFormat7OneDriveIntegrationTests.credential,
-		                                                useBackgroundSession: false,
 		                                                maxPageSize: maxPageSizeForLimitedCloudProvider)
 		let setUpPromise = DecoratorFactory.createFromExistingVaultFormat7(delegate: limitedDelegate, vaultPath: VaultFormat7OneDriveIntegrationTests.vaultPath, password: "IntegrationTest").then { decorator in
 			self.provider = decorator

--- a/Tests/CryptomatorCloudAccessIntegrationTests/Extensions/CloudProvider+CreateIntermediateFolderTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/Extensions/CloudProvider+CreateIntermediateFolderTests.swift
@@ -7,9 +7,9 @@
 //
 
 #if canImport(CryptomatorCloudAccessCore)
-import CryptomatorCloudAccessCore
+@testable import CryptomatorCloudAccessCore
 #else
-import CryptomatorCloudAccess
+@testable import CryptomatorCloudAccess
 #endif
 import Foundation
 import Promises
@@ -70,54 +70,33 @@ class CloudProvider_CreateIntermediateFolderTests: XCTestCase {
 		provider = CloudProviderFolderMock()
 	}
 
-	func testDoesNotCreateAnyFolderForRootPath() throws {
-		let expectation = XCTestExpectation(description: "Create no Folder for passed RootPath")
-		provider.createFolderWithIntermediates(for: CloudPath("/")).then { _ in
-			guard self.provider.createdFolders.isEmpty else {
-				XCTFail("Provider created at least one folder")
-				return
-			}
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+	func testDoesNotCreateAnyFolderForRootPath() async throws {
+		try await provider.createFolderWithIntermediates(for: CloudPath("/")).async()
+		guard provider.createdFolders.isEmpty else {
+			XCTFail("Provider created at least one folder")
+			return
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testCreateFolderWithIntermediates() throws {
-		let expectation = XCTestExpectation(description: "Create all intermediate Folders for CloudPath")
+	func testCreateFolderWithIntermediates() async throws {
 		let path = CloudPath("/Foo/Bar")
-		provider.createFolderWithIntermediates(for: path).then { _ in
-			guard self.provider.createdFolders.count == 2 else {
-				XCTFail("Provider created not exactly two folders")
-				return
-			}
-			XCTAssert(self.provider.createdFolders.contains(CloudPath("/Foo")))
-			XCTAssert(self.provider.createdFolders.contains(CloudPath("/Foo/Bar")))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+		try await provider.createFolderWithIntermediates(for: path).async()
+		guard provider.createdFolders.count == 2 else {
+			XCTFail("Provider created not exactly two folders")
+			return
 		}
-		wait(for: [expectation], timeout: 1.0)
+		XCTAssert(provider.createdFolders.contains(CloudPath("/Foo")))
+		XCTAssert(provider.createdFolders.contains(CloudPath("/Foo/Bar")))
 	}
 
-	func testCreateFolderWithIntermediatesIfAFolderAlreadyExists() throws {
-		let expectation = XCTestExpectation(description: "Create folder without error for CloudPath if the parent folder already exists")
+	func testCreateFolderWithIntermediatesIfAFolderAlreadyExists() async throws {
 		let path = CloudPath("/Foo/Bar")
 		provider.existingFolders.append(CloudPath("/Foo"))
-		provider.createFolderWithIntermediates(for: path).then { _ in
-			guard self.provider.createdFolders.count == 1 else {
-				XCTFail("Provider created not exactly two folders")
-				return
-			}
-			XCTAssert(self.provider.createdFolders.contains(CloudPath("/Foo/Bar")))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+		try await provider.createFolderWithIntermediates(for: path).async()
+		guard provider.createdFolders.count == 1 else {
+			XCTFail("Provider created not exactly two folders")
+			return
 		}
-		wait(for: [expectation], timeout: 1.0)
+		XCTAssert(provider.createdFolders.contains(CloudPath("/Foo/Bar")))
 	}
 }

--- a/Tests/CryptomatorCloudAccessIntegrationTests/Google Drive/GoogleDriveCloudProviderIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/Google Drive/GoogleDriveCloudProviderIntegrationTests.swift
@@ -25,14 +25,14 @@ class GoogleDriveCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAu
 		integrationTestParentCloudPath = CloudPath("/iOS-IntegrationTests-Plain")
 		let credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: "IntegrationTest")
 		// swiftlint:disable:next force_try
-		setUpProvider = try! GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		setUpProvider = try! GoogleDriveCloudProvider(credential: credential)
 		super.setUp()
 	}
 
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		credential = GoogleDriveAuthenticatorMock.generateAuthorizedCredential(withRefreshToken: IntegrationTestSecrets.googleDriveRefreshToken, tokenUID: UUID().uuidString)
-		provider = try GoogleDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		provider = try GoogleDriveCloudProvider(credential: credential)
 	}
 
 	override func deauthenticate() -> Promise<Void> {
@@ -42,7 +42,6 @@ class GoogleDriveCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAu
 
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		return try GoogleDriveCloudProvider(credential: credential,
-		                                    useBackgroundSession: false,
 		                                    maxPageSize: maxPageSizeForLimitedCloudProvider)
 	}
 }

--- a/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveCloudProviderIntegrationTests.swift
+++ b/Tests/CryptomatorCloudAccessIntegrationTests/OneDrive/OneDriveCloudProviderIntegrationTests.swift
@@ -25,14 +25,14 @@ class OneDriveCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAuthe
 	override class func setUp() {
 		integrationTestParentCloudPath = CloudPath("/iOS-IntegrationTests-Plain")
 		// swiftlint:disable:next force_try
-		setUpProvider = try! OneDriveCloudProvider(credential: credential, useBackgroundSession: false)
+		setUpProvider = try! OneDriveCloudProvider(credential: credential)
 		super.setUp()
 	}
 
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		OneDriveCloudProviderIntegrationTests.credential.resetAccessTokenOverride()
-		provider = try OneDriveCloudProvider(credential: OneDriveCloudProviderIntegrationTests.credential, useBackgroundSession: false)
+		provider = try OneDriveCloudProvider(credential: OneDriveCloudProviderIntegrationTests.credential)
 	}
 
 	override func deauthenticate() -> Promise<Void> {
@@ -46,7 +46,6 @@ class OneDriveCloudProviderIntegrationTests: CloudAccessIntegrationTestWithAuthe
 
 	override func createLimitedCloudProvider() throws -> CloudProvider {
 		return try OneDriveCloudProvider(credential: OneDriveCloudProviderIntegrationTests.credential,
-		                                 useBackgroundSession: false,
 		                                 maxPageSize: maxPageSizeForLimitedCloudProvider)
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/DirectoryIdCacheTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/DirectoryIdCacheTests.swift
@@ -55,8 +55,7 @@ class DirectoryIdCacheTests: XCTestCase {
 		XCTAssertEqual(dirId, try cache.get(siblingPath))
 	}
 
-	func testRecursiveGet() throws {
-		let expectation = XCTestExpectation(description: "recursiveGet")
+	func testRecursiveGet() async throws {
 		let path = CloudPath("/one/two/three")
 
 		var misses: [String] = []
@@ -81,13 +80,9 @@ class DirectoryIdCacheTests: XCTestCase {
 			return Promise(Data(dirId.utf8))
 		})
 
-		result.then { data in
-			XCTAssertEqual(Data("THREE".utf8), data)
-		}.always {
-			expectation.fulfill()
-		}
+		let data = try await result.async()
+		XCTAssertEqual(Data("THREE".utf8), data)
 
-		wait(for: [expectation], timeout: 1.0)
 		XCTAssertEqual("ONE", misses[0])
 		XCTAssertEqual("TWO", misses[1])
 		XCTAssertEqual("THREE", misses[2])

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ProviderDecoratorTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ProviderDecoratorTests.swift
@@ -35,143 +35,88 @@ class VaultFormat6ProviderDecoratorTests: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirURL)
 	}
 
-	func testFetchItemMetadata() {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata")
-		decorator.fetchItemMetadata(at: CloudPath("/Directory 1/File 3")).then { metadata in
-			XCTAssertEqual("File 3", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/Directory 1/File 3", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemMetadata() async throws {
+		let metadata = try await decorator.fetchItemMetadata(at: CloudPath("/Directory 1/File 3")).async()
+		XCTAssertEqual("File 3", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/Directory 1/File 3", metadata.cloudPath.path)
 	}
 
-	func testFetchItemListForRootDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for root dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(3, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForRootDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(3, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
 	}
 
-	func testFetchItemListForSubDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for sub dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/Directory 1"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 3" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 2" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForSubDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/Directory 1"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 3" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 2" }))
 	}
 
-	func testDownloadFile() {
-		let expectation = XCTestExpectation(description: "downloadFile")
+	// TODO: Re-enable progress testing if you know how to handle implicit progress reporting in an async method
+	func testDownloadFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		let progress = Progress(totalUnitCount: 1)
-		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
-			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
-		}
-		progress.becomeCurrent(withPendingUnitCount: 1)
-		decorator.downloadFile(from: CloudPath("/File 1"), to: localURL).then {
-			let cleartext = try String(contentsOf: localURL, encoding: .utf8)
-			XCTAssertEqual("cleartext1", cleartext)
-			XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			progressObserver.invalidate()
-			expectation.fulfill()
-		}
-		progress.resignCurrent()
-		wait(for: [expectation], timeout: 1.0)
+//		let progress = Progress(totalUnitCount: 1)
+//		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
+//			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
+//		}
+//		progress.becomeCurrent(withPendingUnitCount: 1)
+		try await decorator.downloadFile(from: CloudPath("/File 1"), to: localURL).async()
+		let cleartext = try String(contentsOf: localURL, encoding: .utf8)
+		XCTAssertEqual("cleartext1", cleartext)
+//		XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
+//		progressObserver.invalidate()
+//		progress.resignCurrent()
 	}
 
-	func testUploadFile() throws {
-		let expectation = XCTestExpectation(description: "uploadFile")
+	// TODO: Re-enable progress testing if you know how to handle implicit progress reporting in an async method
+	func testUploadFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "cleartext1".write(to: localURL, atomically: true, encoding: .utf8)
-		let progress = Progress(totalUnitCount: 1)
-		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
-			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
-		}
-		progress.becomeCurrent(withPendingUnitCount: 1)
-		decorator.uploadFile(from: localURL, to: CloudPath("/File 1"), replaceExisting: false).then { metadata in
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("ciphertext1".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
-			XCTAssertEqual("File 1", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/File 1", metadata.cloudPath.path)
-			XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			progressObserver.invalidate()
-			expectation.fulfill()
-		}
-		progress.resignCurrent()
-		wait(for: [expectation], timeout: 1.0)
+//		let progress = Progress(totalUnitCount: 1)
+//		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
+//			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
+//		}
+//		progress.becomeCurrent(withPendingUnitCount: 1)
+		let metadata = try await decorator.uploadFile(from: localURL, to: CloudPath("/File 1"), replaceExisting: false).async()
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("ciphertext1".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
+		XCTAssertEqual("File 1", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/File 1", metadata.cloudPath.path)
+//		XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
+//		progressObserver.invalidate()
+//		progress.resignCurrent()
 	}
 
-	func testCreateFolder() {
-		let expectation = XCTestExpectation(description: "createFolder")
-		decorator.createFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(2, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testCreateFolder() async throws {
+		try await decorator.createFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(2, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"])
 	}
 
-	func testDeleteFile() {
-		let expectation = XCTestExpectation(description: "deleteFile")
-		decorator.deleteFile(at: CloudPath("/Directory 1/File 3")).then {
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file3"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFile() async throws {
+		try await decorator.deleteFile(at: CloudPath("/Directory 1/File 3")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file3"))
 	}
 
-	func testDeleteFolder() {
-		let expectation = XCTestExpectation(description: "deleteFolder")
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(3, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/22/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFolder() async throws {
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(3, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/22/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
 	}
 
-	func testDeleteFolderWithMissingDirFile() throws {
-		let expectation = XCTestExpectation(description: "deleteFolder")
+	func testDeleteFolderWithMissingDirFile() async throws {
 		// pathToVault
 		// └─Directory 1
 		//   ├─ Directory 2
@@ -191,19 +136,12 @@ class VaultFormat6ProviderDecoratorTests: XCTestCase {
 
 		let provider = VaultFormat6CloudProviderMock(folders: folders, files: files)
 		let decorator = try VaultFormat6ProviderDecorator(delegate: provider, vaultPath: vaultPath, cryptor: cryptor)
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, provider.deleted.count)
-			XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
 	}
 
-	func testDeleteFolderWithBrokenFolder() throws {
-		let expectation = XCTestExpectation(description: "deleteFolder")
+	func testDeleteFolderWithBrokenFolder() async throws {
 		let folders: Set = [
 			"pathToVault",
 			"pathToVault/d",
@@ -216,27 +154,14 @@ class VaultFormat6ProviderDecoratorTests: XCTestCase {
 		]
 		let provider = VaultFormat6CloudProviderMock(folders: folders, files: files)
 		let decorator = try VaultFormat6ProviderDecorator(delegate: provider, vaultPath: vaultPath, cryptor: cryptor)
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, provider.deleted.count)
-			XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"))
 	}
 
-	func testMoveFile() {
-		let expectation = XCTestExpectation(description: "moveFile")
-		decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/Directory 1/File 2")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file2", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFile() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/Directory 1/File 2")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file2", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ShortenedNameCacheTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ShortenedNameCacheTests.swift
@@ -48,19 +48,14 @@ class VaultFormat6ShortenedNameCacheTests: XCTestCase {
 		XCTAssertFalse(shortened.pointsToLNG)
 	}
 
-	func testGetOriginalPath() {
+	func testGetOriginalPath() async throws {
 		let shortened = CloudPath("/foo/bar/d/2/30/shortened.lng")
-		let expectation = XCTestExpectation(description: "callback called")
 
-		cache.getOriginalPath(shortened) { lngFileName -> Promise<Data> in
+		let longName = try await cache.getOriginalPath(shortened) { lngFileName -> Promise<Data> in
 			XCTAssertEqual("shortened.lng", lngFileName)
 			return Promise("loooong".data(using: .utf8)!)
-		}.then { longName in
-			XCTAssertEqual("/foo/bar/d/2/30/loooong", longName.path)
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		}.async()
+		XCTAssertEqual("/foo/bar/d/2/30/loooong", longName.path)
 	}
 
 	func testDeflatePath() throws {

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecoratorTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat6/VaultFormat6ShorteningProviderDecoratorTests.swift
@@ -29,217 +29,126 @@ class VaultFormat6ShorteningProviderDecoratorTests: VaultFormat6ProviderDecorato
 		try super.tearDownWithError()
 	}
 
-	override func testFetchItemListForRootDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for root dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(6, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 3 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 4 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 5 (Long)" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	override func testFetchItemListForRootDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(6, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 3 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 4 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 5 (Long)" }))
 	}
 
-	func testFetchItemMetadataWithLongName() {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata with long name")
-		decorator.fetchItemMetadata(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).then { metadata in
-			XCTAssertEqual("File 6 (Long)", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/Directory 3 (Long)/File 6 (Long)", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemMetadataWithLongName() async throws {
+		let metadata = try await decorator.fetchItemMetadata(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).async()
+		XCTAssertEqual("File 6 (Long)", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/Directory 3 (Long)/File 6 (Long)", metadata.cloudPath.path)
 	}
 
-	func testFetchItemListForSubDirWithLongName() {
-		let expectation = XCTestExpectation(description: "fetchItemList for sub dir with long name")
-		decorator.fetchItemList(forFolderAt: CloudPath("/Directory 3 (Long)"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 6 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 4 (Long)" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForSubDirWithLongName() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/Directory 3 (Long)"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 6 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 4 (Long)" }))
 	}
 
-	func testDownloadFileWithLongName() {
-		let expectation = XCTestExpectation(description: "downloadFile with long name")
+	func testDownloadFileWithLongName() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		decorator.downloadFile(from: CloudPath("/File 4 (Long)"), to: localURL).then {
-			let cleartext = try String(contentsOf: localURL, encoding: .utf8)
-			XCTAssertEqual("cleartext4", cleartext)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.downloadFile(from: CloudPath("/File 4 (Long)"), to: localURL).async()
+		let cleartext = try String(contentsOf: localURL, encoding: .utf8)
+		XCTAssertEqual("cleartext4", cleartext)
 	}
 
-	func testUploadFileWithLongName() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with long name")
+	func testUploadFileWithLongName() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "cleartext4".write(to: localURL, atomically: true, encoding: .utf8)
-		decorator.uploadFile(from: localURL, to: CloudPath("/File 4 (Long)"), replaceExisting: false).then { metadata in
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/2Q"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/2Q/OD"))
-			XCTAssertEqual(2, self.provider.createdFiles.count)
-			XCTAssertEqual("ciphertext4".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
-			XCTAssertEqual(String(repeating: "file4", count: 26).data(using: .utf8), self.provider.createdFiles["pathToVault/m/2Q/OD/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
-			XCTAssertEqual("File 4 (Long)", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/File 4 (Long)", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await decorator.uploadFile(from: localURL, to: CloudPath("/File 4 (Long)"), replaceExisting: false).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/2Q"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/2Q/OD"))
+		XCTAssertEqual(2, provider.createdFiles.count)
+		XCTAssertEqual("ciphertext4".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
+		XCTAssertEqual(String(repeating: "file4", count: 26).data(using: .utf8), provider.createdFiles["pathToVault/m/2Q/OD/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
+		XCTAssertEqual("File 4 (Long)", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/File 4 (Long)", metadata.cloudPath.path)
 	}
 
-	func testCreateFolderWithLongName() {
-		let expectation = XCTestExpectation(description: "createFolder with long name")
-		decorator.createFolder(at: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(5, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/DL"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/DL/2X"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
-			XCTAssertEqual(2, self.provider.createdFiles.count)
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
-			XCTAssertEqual("0\(String(repeating: "dir3", count: 33))".data(using: .utf8), self.provider.createdFiles["pathToVault/m/DL/2X/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testCreateFolderWithLongName() async throws {
+		try await decorator.createFolder(at: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(5, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/DL"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/DL/2X"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
+		XCTAssertEqual(2, provider.createdFiles.count)
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
+		XCTAssertEqual("0\(String(repeating: "dir3", count: 33))".data(using: .utf8), provider.createdFiles["pathToVault/m/DL/2X/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
 	}
 
-	func testDeleteFileWithLongName() {
-		let expectation = XCTestExpectation(description: "deleteFile with long name")
-		decorator.deleteFile(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).then {
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD/LTGFEUKABMKGWWR2EAL6LSHZC7OGDRMN.lng"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFileWithLongName() async throws {
+		try await decorator.deleteFile(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD/LTGFEUKABMKGWWR2EAL6LSHZC7OGDRMN.lng"))
 	}
 
-	func testDeleteFolderWithLongName() {
-		let expectation = XCTestExpectation(description: "deleteFolder with long name")
-		decorator.deleteFolder(at: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(3, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/44/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFolderWithLongName() async throws {
+		try await decorator.deleteFolder(at: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(3, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/44/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"))
 	}
 
-	func testMoveFileFromShortToLongName() {
-		let expectation = XCTestExpectation(description: "moveFile from short to long name")
-		decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/File 4 (Long)")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/2Q"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/2Q/OD"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual(String(repeating: "file4", count: 26).data(using: .utf8), self.provider.createdFiles["pathToVault/m/2Q/OD/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromShortToLongName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/File 4 (Long)")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/2Q"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/2Q/OD"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual(String(repeating: "file4", count: 26).data(using: .utf8), provider.createdFiles["pathToVault/m/2Q/OD/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1"])
 	}
 
-	func testMoveFileFromLongToShortName() {
-		let expectation = XCTestExpectation(description: "moveFile from long to short name")
-		decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 1")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromLongToShortName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 1")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
 	}
 
-	func testMoveFileFromLongToLongName() {
-		let expectation = XCTestExpectation(description: "moveFile from long to long name")
-		decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 5 (Long)")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/CI"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/CI/VV"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual(String(repeating: "file5", count: 26).data(using: .utf8), self.provider.createdFiles["pathToVault/m/CI/VV/CIVVSN3UPME74I7TGQESFYRUFKAUH6H7.lng"])
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/CIVVSN3UPME74I7TGQESFYRUFKAUH6H7.lng", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromLongToLongName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 5 (Long)")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/CI"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/CI/VV"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual(String(repeating: "file5", count: 26).data(using: .utf8), provider.createdFiles["pathToVault/m/CI/VV/CIVVSN3UPME74I7TGQESFYRUFKAUH6H7.lng"])
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/CIVVSN3UPME74I7TGQESFYRUFKAUH6H7.lng", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/2QODSHBUSLEFQ6UELQ45EKJ27HTAMZPH.lng"])
 	}
 
-	func testMoveFolderFromShortToLongName() {
-		let expectation = XCTestExpectation(description: "moveFolder from short to long name")
-		decorator.moveFolder(from: CloudPath("/Directory 1"), to: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/DL"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/m/DL/2X"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("0\(String(repeating: "dir3", count: 33))".data(using: .utf8), self.provider.createdFiles["pathToVault/m/DL/2X/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFolderFromShortToLongName() async throws {
+		try await decorator.moveFolder(from: CloudPath("/Directory 1"), to: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/DL"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/m/DL/2X"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("0\(String(repeating: "dir3", count: 33))".data(using: .utf8), provider.createdFiles["pathToVault/m/DL/2X/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1"])
 	}
 
-	func testMoveFolderFromLongToShortName() {
-		let expectation = XCTestExpectation(description: "moveFolder from long to short name")
-		decorator.moveFolder(from: CloudPath("/Directory 3 (Long)"), to: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFolderFromLongToShortName() async throws {
+		try await decorator.moveFolder(from: CloudPath("/Directory 3 (Long)"), to: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/0dir1", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/DL2XHF4PL5BKUCEJFIOEWB5JPAURMP3Y.lng"])
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7CloudProviderMockTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7CloudProviderMockTests.swift
@@ -26,40 +26,25 @@ class VaultFormat7CloudProviderMockTests: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirURL)
 	}
 
-	func testVaultRootContainsFiles() {
-		let expectation = XCTestExpectation(description: "vaultRootContainsFiles")
+	func testVaultRootContainsFiles() async throws {
 		let provider = VaultFormat7CloudProviderMock()
-		provider.fetchItemList(forFolderAt: CloudPath("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), withPageToken: nil).then { cloudItemList in
-			XCTAssertEqual(6, cloudItemList.items.count)
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "dir1.c9r" }))
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s" }))
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "file1.c9r" }))
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "file2.c9r" }))
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s" }))
-			XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let cloudItemList = try await provider.fetchItemList(forFolderAt: CloudPath("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"), withPageToken: nil).async()
+		XCTAssertEqual(6, cloudItemList.items.count)
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "dir1.c9r" }))
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s" }))
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "file1.c9r" }))
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "file2.c9r" }))
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s" }))
+		XCTAssertTrue(cloudItemList.items.contains(where: { $0.name == "aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s" }))
 	}
 
-	func testDir1FileContainsDirId() {
-		let expectation = XCTestExpectation(description: "dir1FileContainsDirId")
+	func testDir1FileContainsDirId() async throws {
 		let provider = VaultFormat7CloudProviderMock()
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		provider.fetchItemMetadata(at: CloudPath("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r")).then { metadata -> Promise<Void> in
-			XCTAssertEqual(.file, metadata.itemType)
-			return provider.downloadFile(from: metadata.cloudPath, to: localURL)
-		}.then {
-			let downloadedContents = try Data(contentsOf: localURL)
-			XCTAssertEqual("dir1-id".data(using: .utf8), downloadedContents)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await provider.fetchItemMetadata(at: CloudPath("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r")).async()
+		XCTAssertEqual(.file, metadata.itemType)
+		try await provider.downloadFile(from: metadata.cloudPath, to: localURL).async()
+		let downloadedContents = try Data(contentsOf: localURL)
+		XCTAssertEqual("dir1-id".data(using: .utf8), downloadedContents)
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ProviderDecoratorTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ProviderDecoratorTests.swift
@@ -36,144 +36,89 @@ class VaultFormat7ProviderDecoratorTests: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirURL)
 	}
 
-	func testFetchItemMetadata() {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata")
-		decorator.fetchItemMetadata(at: CloudPath("/Directory 1/File 3")).then { metadata in
-			XCTAssertEqual("File 3", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/Directory 1/File 3", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemMetadata() async throws {
+		let metadata = try await decorator.fetchItemMetadata(at: CloudPath("/Directory 1/File 3")).async()
+		XCTAssertEqual("File 3", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/Directory 1/File 3", metadata.cloudPath.path)
 	}
 
-	func testFetchItemListForRootDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for root dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(3, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForRootDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(3, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
 	}
 
-	func testFetchItemListForSubDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for sub dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/Directory 1"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 3" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 2" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForSubDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/Directory 1"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 3" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 2" }))
 	}
 
-	func testDownloadFile() {
-		let expectation = XCTestExpectation(description: "downloadFile")
+	// TODO: Re-enable progress testing if you know how to handle implicit progress reporting in an async method
+	func testDownloadFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		let progress = Progress(totalUnitCount: 1)
-		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
-			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
-		}
-		progress.becomeCurrent(withPendingUnitCount: 1)
-		decorator.downloadFile(from: CloudPath("/File 1"), to: localURL).then {
-			let cleartext = try String(contentsOf: localURL, encoding: .utf8)
-			XCTAssertEqual("cleartext1", cleartext)
-			XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			progressObserver.invalidate()
-			expectation.fulfill()
-		}
-		progress.resignCurrent()
-		wait(for: [expectation], timeout: 1.0)
+//		let progress = Progress(totalUnitCount: 1)
+//		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
+//			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
+//		}
+//		progress.becomeCurrent(withPendingUnitCount: 1)
+		try await decorator.downloadFile(from: CloudPath("/File 1"), to: localURL).async()
+		let cleartext = try String(contentsOf: localURL, encoding: .utf8)
+		XCTAssertEqual("cleartext1", cleartext)
+//		XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
+//		progressObserver.invalidate()
+//		progress.resignCurrent()
 	}
 
-	func testUploadFile() throws {
-		let expectation = XCTestExpectation(description: "uploadFile")
+	// TODO: Re-enable progress testing if you know how to handle implicit progress reporting in an async method
+	func testUploadFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "cleartext1".write(to: localURL, atomically: true, encoding: .utf8)
-		let progress = Progress(totalUnitCount: 1)
-		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
-			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
-		}
-		progress.becomeCurrent(withPendingUnitCount: 1)
-		decorator.uploadFile(from: localURL, to: CloudPath("/File 1"), replaceExisting: false).then { metadata in
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("ciphertext1".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
-			XCTAssertEqual("File 1", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/File 1", metadata.cloudPath.path)
-			XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			progressObserver.invalidate()
-			expectation.fulfill()
-		}
-		progress.resignCurrent()
-		wait(for: [expectation], timeout: 1.0)
+//		let progress = Progress(totalUnitCount: 1)
+//		let progressObserver = progress.observe(\.fractionCompleted) { progress, _ in
+//			print("\(progress.localizedDescription ?? "") (\(progress.localizedAdditionalDescription ?? ""))")
+//		}
+//		progress.becomeCurrent(withPendingUnitCount: 1)
+		let metadata = try await decorator.uploadFile(from: localURL, to: CloudPath("/File 1"), replaceExisting: false).async()
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("ciphertext1".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
+		XCTAssertEqual("File 1", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/File 1", metadata.cloudPath.path)
+//		XCTAssertTrue(progress.completedUnitCount >= progress.totalUnitCount)
+//		progressObserver.invalidate()
+//		progress.resignCurrent()
 	}
 
-	func testCreateFolder() {
-		let expectation = XCTestExpectation(description: "createFolder")
-		decorator.createFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testCreateFolder() async throws {
+		try await decorator.createFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r"])
 	}
 
-	func testDeleteFile() {
-		let expectation = XCTestExpectation(description: "deleteFile")
-		decorator.deleteFile(at: CloudPath("/Directory 1/File 3")).then {
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file3.c9r"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFile() async throws {
+		try await decorator.deleteFile(at: CloudPath("/Directory 1/File 3")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file3.c9r"))
 	}
 
-	func testDeleteFolder() {
-		let expectation = XCTestExpectation(description: "deleteFolder")
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(3, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/22/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFolder() async throws {
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(3, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/22/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
 	}
 
-	func testDeleteFolderWithMissingDirFile() throws {
-		let expectation = XCTestExpectation(description: "deleteFolder")
+	func testDeleteFolderWithMissingDirFile() async throws {
 		// pathToVault
 		// └─Directory 1
 		//   ├─ Directory 2
@@ -194,19 +139,12 @@ class VaultFormat7ProviderDecoratorTests: XCTestCase {
 		]
 		let provider = VaultFormat7CloudProviderMock(folders: folders, files: files)
 		let decorator = try VaultFormat7ProviderDecorator(delegate: provider, vaultPath: vaultPath, cryptor: cryptor)
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, provider.deleted.count)
-			XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
 	}
 
-	func testDeleteFolderWithBrokenFolder() throws {
-		let expectation = XCTestExpectation(description: "deleteFolder")
+	func testDeleteFolderWithBrokenFolder() async throws {
 		let folders: Set = [
 			"pathToVault",
 			"pathToVault/d",
@@ -219,27 +157,14 @@ class VaultFormat7ProviderDecoratorTests: XCTestCase {
 		]
 		let provider = VaultFormat7CloudProviderMock(folders: folders, files: files)
 		let decorator = try VaultFormat7ProviderDecorator(delegate: provider, vaultPath: vaultPath, cryptor: cryptor)
-		decorator.deleteFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, provider.deleted.count)
-			XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.deleteFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
 	}
 
-	func testMoveFile() {
-		let expectation = XCTestExpectation(description: "moveFile")
-		decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/Directory 1/File 2")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file2.c9r", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFile() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/Directory 1/File 2")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/11/BBBBBBBBBBBBBBBBBBBBBBBBBBBBBB/file2.c9r", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ShortenedNameCacheTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ShortenedNameCacheTests.swift
@@ -64,34 +64,24 @@ class VaultFormat7ShortenedNameCacheTests: XCTestCase {
 		XCTAssertFalse(shortened.pointsToC9S)
 	}
 
-	func testGetOriginalPath1() {
+	func testGetOriginalPath1() async throws {
 		let shortened = CloudPath("/foo/bar/d/2/30/shortened.c9s")
-		let expectation = XCTestExpectation(description: "callback called")
 
-		cache.getOriginalPath(shortened) { cloudPath -> Promise<Data> in
+		let longName = try await cache.getOriginalPath(shortened) { cloudPath -> Promise<Data> in
 			XCTAssertEqual("/foo/bar/d/2/30/shortened.c9s", cloudPath.path)
 			return Promise("loooong.c9r".data(using: .utf8)!)
-		}.then { longName in
-			XCTAssertEqual("/foo/bar/d/2/30/loooong.c9r", longName.path)
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		}.async()
+		XCTAssertEqual("/foo/bar/d/2/30/loooong.c9r", longName.path)
 	}
 
-	func testGetOriginalPath2() {
+	func testGetOriginalPath2() async throws {
 		let shortened = CloudPath("/foo/bar/d/2/30/shortened.c9s/dir.c9r")
-		let expectation = XCTestExpectation(description: "callback called")
 
-		cache.getOriginalPath(shortened) { cloudPath -> Promise<Data> in
+		let longName = try await cache.getOriginalPath(shortened) { cloudPath -> Promise<Data> in
 			XCTAssertEqual("/foo/bar/d/2/30/shortened.c9s", cloudPath.path)
 			return Promise("loooong.c9r".data(using: .utf8)!)
-		}.then { longName in
-			XCTAssertEqual("/foo/bar/d/2/30/loooong.c9r/dir.c9r", longName.path)
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		}.async()
+		XCTAssertEqual("/foo/bar/d/2/30/loooong.c9r/dir.c9r", longName.path)
 	}
 
 	func testDeflatePath1() throws {

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecoratorTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat7/VaultFormat7ShorteningProviderDecoratorTests.swift
@@ -29,205 +29,114 @@ class VaultFormat7ShorteningProviderDecoratorTests: VaultFormat7ProviderDecorato
 		try super.tearDownWithError()
 	}
 
-	override func testFetchItemListForRootDir() {
-		let expectation = XCTestExpectation(description: "fetchItemList for root dir")
-		decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(6, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 3 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 4 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 5 (Long)" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	override func testFetchItemListForRootDir() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(6, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 3 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 1" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 2" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 4 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 5 (Long)" }))
 	}
 
-	func testFetchItemMetadataWithLongName() {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata with long name")
-		decorator.fetchItemMetadata(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).then { metadata in
-			XCTAssertEqual("File 6 (Long)", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/Directory 3 (Long)/File 6 (Long)", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemMetadataWithLongName() async throws {
+		let metadata = try await decorator.fetchItemMetadata(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).async()
+		XCTAssertEqual("File 6 (Long)", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/Directory 3 (Long)/File 6 (Long)", metadata.cloudPath.path)
 	}
 
-	func testFetchItemListForSubDirWithLongName() {
-		let expectation = XCTestExpectation(description: "fetchItemList for sub dir with long name")
-		decorator.fetchItemList(forFolderAt: CloudPath("/Directory 3 (Long)"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 6 (Long)" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 4 (Long)" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testFetchItemListForSubDirWithLongName() async throws {
+		let itemList = try await decorator.fetchItemList(forFolderAt: CloudPath("/Directory 3 (Long)"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "File 6 (Long)" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "Directory 4 (Long)" }))
 	}
 
-	func testDownloadFileWithLongName() {
-		let expectation = XCTestExpectation(description: "downloadFile with long name")
+	func testDownloadFileWithLongName() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		decorator.downloadFile(from: CloudPath("/File 4 (Long)"), to: localURL).then {
-			let cleartext = try String(contentsOf: localURL, encoding: .utf8)
-			XCTAssertEqual("cleartext4", cleartext)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await decorator.downloadFile(from: CloudPath("/File 4 (Long)"), to: localURL).async()
+		let cleartext = try String(contentsOf: localURL, encoding: .utf8)
+		XCTAssertEqual("cleartext4", cleartext)
 	}
 
-	func testUploadFileWithLongName() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with long name")
+	func testUploadFileWithLongName() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "cleartext4".write(to: localURL, atomically: true, encoding: .utf8)
-		decorator.uploadFile(from: localURL, to: CloudPath("/File 4 (Long)"), replaceExisting: false).then { metadata in
-			XCTAssertEqual(2, self.provider.createdFiles.count)
-			XCTAssertEqual("ciphertext4".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r"])
-			XCTAssertEqual("\(String(repeating: "file4", count: 44)).c9r".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/name.c9s"])
-			XCTAssertEqual("File 4 (Long)", metadata.name)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertEqual("/File 4 (Long)", metadata.cloudPath.path)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await decorator.uploadFile(from: localURL, to: CloudPath("/File 4 (Long)"), replaceExisting: false).async()
+		XCTAssertEqual(2, provider.createdFiles.count)
+		XCTAssertEqual("ciphertext4".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r"])
+		XCTAssertEqual("\(String(repeating: "file4", count: 44)).c9r".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/name.c9s"])
+		XCTAssertEqual("File 4 (Long)", metadata.name)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertEqual("/File 4 (Long)", metadata.cloudPath.path)
 	}
 
-	func testCreateFolderWithLongName() {
-		let expectation = XCTestExpectation(description: "createFolder with long name")
-		decorator.createFolder(at: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
-			XCTAssertEqual(2, self.provider.createdFiles.count)
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/dir.c9r"])
-			XCTAssertEqual("\(String(repeating: "dir3", count: 55)).c9r".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/name.c9s"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testCreateFolderWithLongName() async throws {
+		try await decorator.createFolder(at: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
+		XCTAssertEqual(2, provider.createdFiles.count)
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/dir.c9r"])
+		XCTAssertEqual("\(String(repeating: "dir3", count: 55)).c9r".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/name.c9s"])
 	}
 
-	func testDeleteFileWithLongName() {
-		let expectation = XCTestExpectation(description: "deleteFile with long name")
-		decorator.deleteFile(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).then {
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD/nSuAAJhIy1kp2_GdVZ0KgqaLJ-U=.c9s"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFileWithLongName() async throws {
+		try await decorator.deleteFile(at: CloudPath("/Directory 3 (Long)/File 6 (Long)")).async()
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD/nSuAAJhIy1kp2_GdVZ0KgqaLJ-U=.c9s"))
 	}
 
-	func testDeleteFolderWithLongName() {
-		let expectation = XCTestExpectation(description: "deleteFolder with long name")
-		decorator.deleteFolder(at: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(3, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/44/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"))
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testDeleteFolderWithLongName() async throws {
+		try await decorator.deleteFolder(at: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(3, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/44/EEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/33/DDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"))
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"))
 	}
 
-	func testMoveFileFromShortToLongName() {
-		let expectation = XCTestExpectation(description: "moveFile from short to long name")
-		decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/File 4 (Long)")).then {
-			XCTAssertEqual(1, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"))
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("\(String(repeating: "file4", count: 44)).c9r".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/name.c9s"])
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromShortToLongName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 1"), to: CloudPath("/File 4 (Long)")).async()
+		XCTAssertEqual(1, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"))
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("\(String(repeating: "file4", count: 44)).c9r".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/name.c9s"])
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r"])
 	}
 
-	func testMoveFileFromLongToShortName() {
-		let expectation = XCTestExpectation(description: "moveFile from long to short name")
-		decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 1")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r"])
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromLongToShortName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 1")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/file1.c9r", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s/contents.c9r"])
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"))
 	}
 
-	func testMoveFileFromLongToLongName() {
-		let expectation = XCTestExpectation(description: "moveFile from long to long name")
-		decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 5 (Long)")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"])
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("\(String(repeating: "file5", count: 44)).c9r".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s/name.c9s"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFileFromLongToLongName() async throws {
+		try await decorator.moveFile(from: CloudPath("/File 4 (Long)"), to: CloudPath("/File 5 (Long)")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/9j5eVKQZdTojV6zlbxhcCLD_8bs=.c9s"])
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("\(String(repeating: "file5", count: 44)).c9r".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/aw1qoKFUVs_FnB_n3lGtqKpyIeA=.c9s/name.c9s"])
 	}
 
-	func testMoveFolderFromShortToLongName() {
-		let expectation = XCTestExpectation(description: "moveFolder from short to long name")
-		decorator.moveFolder(from: CloudPath("/Directory 1"), to: CloudPath("/Directory 3 (Long)")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"])
-			XCTAssertEqual(1, self.provider.createdFiles.count)
-			XCTAssertEqual("\(String(repeating: "dir3", count: 55)).c9r".data(using: .utf8), self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/name.c9s"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFolderFromShortToLongName() async throws {
+		try await decorator.moveFolder(from: CloudPath("/Directory 1"), to: CloudPath("/Directory 3 (Long)")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"])
+		XCTAssertEqual(1, provider.createdFiles.count)
+		XCTAssertEqual("\(String(repeating: "dir3", count: 55)).c9r".data(using: .utf8), provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s/name.c9s"])
 	}
 
-	func testMoveFolderFromLongToShortName() {
-		let expectation = XCTestExpectation(description: "moveFolder from long to short name")
-		decorator.moveFolder(from: CloudPath("/Directory 3 (Long)"), to: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(1, self.provider.moved.count)
-			XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r", self.provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"])
-			XCTAssertEqual(1, self.provider.deleted.count)
-			XCTAssertTrue(self.provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/name.c9s"))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testMoveFolderFromLongToShortName() async throws {
+		try await decorator.moveFolder(from: CloudPath("/Directory 3 (Long)"), to: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(1, provider.moved.count)
+		XCTAssertEqual("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r", provider.moved["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/kUDsIDxDMxx1lK0CD1ZftCF376Y=.c9s"])
+		XCTAssertEqual(1, provider.deleted.count)
+		XCTAssertTrue(provider.deleted.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/name.c9s"))
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat8/VaultFormat8ProviderDecoratorTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Crypto/VaultFormat8/VaultFormat8ProviderDecoratorTests.swift
@@ -36,21 +36,14 @@ class VaultFormat8ProviderDecoratorTests: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirURL)
 	}
 
-	func testCreateFolder() {
-		let expectation = XCTestExpectation(description: "createFolder")
-		decorator.createFolder(at: CloudPath("/Directory 1")).then {
-			XCTAssertEqual(3, self.provider.createdFolders.count)
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99"))
-			XCTAssertTrue(self.provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
-			XCTAssertEqual(2, self.provider.createdFiles.count)
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r"])
-			XCTAssertNotNil(self.provider.createdFiles["pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ/dirid.c9r"])
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+	func testCreateFolder() async throws {
+		try await decorator.createFolder(at: CloudPath("/Directory 1")).async()
+		XCTAssertEqual(3, provider.createdFolders.count)
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99"))
+		XCTAssertTrue(provider.createdFolders.contains("pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ"))
+		XCTAssertEqual(2, provider.createdFiles.count)
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/00/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA/dir1.c9r/dir.c9r"])
+		XCTAssertNotNil(provider.createdFiles["pathToVault/d/99/ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ/dirid.c9r"])
 	}
 }

--- a/Tests/CryptomatorCloudAccessTests/LocalFileSystem/LocalFileSystemTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/LocalFileSystem/LocalFileSystemTests.swift
@@ -28,91 +28,49 @@ class LocalFileSystemTests: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirURL)
 	}
 
-	func testFetchItemMetadata() throws {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata")
+	func testFetchItemMetadata() async throws {
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		try "hello world".write(to: fileURL, atomically: true, encoding: .utf8)
-		provider.fetchItemMetadata(at: CloudPath("/file")).then { metadata in
-			XCTAssertEqual("file", metadata.name)
-			XCTAssertEqual("/file", metadata.cloudPath.path)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertNotNil(metadata.lastModifiedDate)
-			XCTAssertEqual(11, metadata.size)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await provider.fetchItemMetadata(at: CloudPath("/file")).async()
+		XCTAssertEqual("file", metadata.name)
+		XCTAssertEqual("/file", metadata.cloudPath.path)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertNotNil(metadata.lastModifiedDate)
+		XCTAssertEqual(11, metadata.size)
 	}
 
-	func testFetchItemMetadataWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "fetchItemMetadata with itemNotFound error")
-		provider.fetchItemMetadata(at: CloudPath("/file")).then { _ in
-			XCTFail("Fetching metdata of a non-existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+	func testFetchItemMetadataWithNotFoundError() async {
+		await XCTAssertThrowsErrorAsync(try await provider.fetchItemMetadata(at: CloudPath("/file")).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testFetchItemList() throws {
-		let expectation = XCTestExpectation(description: "fetchItemList")
+	func testFetchItemList() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
 		try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: false, attributes: nil)
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
-		provider.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "dir" && $0.cloudPath.path == "/dir" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "file" && $0.cloudPath.path == "/file" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let itemList = try await provider.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "dir" && $0.cloudPath.path == "/dir" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "file" && $0.cloudPath.path == "/file" }))
 	}
 
-	func testFetchItemListWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "fetchItemList with itemNotFound error")
-		provider.fetchItemList(forFolderAt: CloudPath("/dir"), withPageToken: nil).then { _ in
-			XCTFail("Fetching item list for a non-existing folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+	func testFetchItemListWithNotFoundError() async {
+		await XCTAssertThrowsErrorAsync(try await provider.fetchItemList(forFolderAt: CloudPath("/dir"), withPageToken: nil).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testFetchItemListWithTypeMismatchError() throws {
-		let expectation = XCTestExpectation(description: "fetchItemList with itemTypeMismatch error")
+	func testFetchItemListWithTypeMismatchError() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
 		FileManager.default.createFile(atPath: dirURL.path, contents: nil, attributes: nil)
-		provider.fetchItemList(forFolderAt: CloudPath("/dir"), withPageToken: nil).then { _ in
-			XCTFail("Fetching item list for a folder that is actually a file should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemTypeMismatch = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.fetchItemList(forFolderAt: CloudPath("/dir"), withPageToken: nil).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemTypeMismatch, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testFetchItemListFiltersHiddenItems() throws {
-		let expectation = XCTestExpectation(description: "fetchItemList")
+	func testFetchItemListFiltersHiddenItems() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
 		try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: false, attributes: nil)
 		let hiddenDirURL = tmpDirURL.appendingPathComponent(".hiddenDir", isDirectory: true)
@@ -121,389 +79,202 @@ class LocalFileSystemTests: XCTestCase {
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
 		let hiddenFileURL = tmpDirURL.appendingPathComponent(".hiddenFile", isDirectory: false)
 		FileManager.default.createFile(atPath: hiddenFileURL.path, contents: nil, attributes: nil)
-		provider.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).then { itemList in
-			XCTAssertEqual(2, itemList.items.count)
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "dir" && $0.cloudPath.path == "/dir" }))
-			XCTAssertTrue(itemList.items.contains(where: { $0.name == "file" && $0.cloudPath.path == "/file" }))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let itemList = try await provider.fetchItemList(forFolderAt: CloudPath("/"), withPageToken: nil).async()
+		XCTAssertEqual(2, itemList.items.count)
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "dir" && $0.cloudPath.path == "/dir" }))
+		XCTAssertTrue(itemList.items.contains(where: { $0.name == "file" && $0.cloudPath.path == "/file" }))
 	}
 
-	func testDownloadFile() throws {
-		let expectation = XCTestExpectation(description: "downloadFile")
+	func testDownloadFile() async throws {
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		try "hello world".write(to: fileURL, atomically: true, encoding: .utf8)
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		provider.downloadFile(from: CloudPath("/file"), to: localURL).then {
-			let expectedData = try Data(contentsOf: fileURL)
-			let actualData = try Data(contentsOf: localURL)
-			XCTAssertEqual(expectedData, actualData)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await provider.downloadFile(from: CloudPath("/file"), to: localURL).async()
+		let expectedData = try Data(contentsOf: fileURL)
+		let actualData = try Data(contentsOf: localURL)
+		XCTAssertEqual(expectedData, actualData)
 	}
 
-	func testDownloadFileWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "downloadFile with itemNotFound error")
+	func testDownloadFileWithNotFoundError() async {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		provider.downloadFile(from: CloudPath("/file"), to: localURL).then {
-			XCTFail("Downloading non-existing file should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.downloadFile(from: CloudPath("/file"), to: localURL).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testDownloadFileWithAlreadyExistsError() throws {
-		let expectation = XCTestExpectation(description: "downloadFile with itemAlreadyExists error")
+	func testDownloadFileWithAlreadyExistsError() async {
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		FileManager.default.createFile(atPath: localURL.path, contents: nil, attributes: nil)
-		provider.downloadFile(from: CloudPath("/file"), to: localURL).then {
-			XCTFail("Downloading file to an existing resource should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemAlreadyExists = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.downloadFile(from: CloudPath("/file"), to: localURL).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemAlreadyExists, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testDownloadFileWithTypeMismatchError() throws {
+	func testDownloadFileWithTypeMismatchError() async throws {
 		let expectation = XCTestExpectation(description: "downloadFile with itemTypeMismatch error")
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		try FileManager.default.createDirectory(at: fileURL, withIntermediateDirectories: false, attributes: nil)
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		provider.downloadFile(from: CloudPath("/file"), to: localURL).then {
-			XCTFail("Downloading file that is actually a folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemTypeMismatch = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.downloadFile(from: CloudPath("/file"), to: localURL).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemTypeMismatch, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFile() throws {
-		let expectation = XCTestExpectation(description: "uploadFile")
+	func testUploadFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "hello world".write(to: localURL, atomically: true, encoding: .utf8)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).then { metadata in
-			XCTAssertEqual("file", metadata.name)
-			XCTAssertEqual("/file", metadata.cloudPath.path)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertNotNil(metadata.lastModifiedDate)
-			XCTAssertEqual(11, metadata.size)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).async()
+		XCTAssertEqual("file", metadata.name)
+		XCTAssertEqual("/file", metadata.cloudPath.path)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertNotNil(metadata.lastModifiedDate)
+		XCTAssertEqual(11, metadata.size)
 	}
 
-	func testUploadFileWithReplaceExistingOnMissingRemoteFile() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with replaceExisting on missing remote file")
+	func testUploadFileWithReplaceExistingOnMissingRemoteFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "hello world".write(to: localURL, atomically: true, encoding: .utf8)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: true).then { metadata in
-			XCTAssertEqual("file", metadata.name)
-			XCTAssertEqual("/file", metadata.cloudPath.path)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertNotNil(metadata.lastModifiedDate)
-			XCTAssertEqual(11, metadata.size)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: true).async()
+		XCTAssertEqual("file", metadata.name)
+		XCTAssertEqual("/file", metadata.cloudPath.path)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertNotNil(metadata.lastModifiedDate)
+		XCTAssertEqual(11, metadata.size)
 	}
 
-	func testUploadFileWithReplaceExistingOnExistingRemoteFile() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with replaceExisting on existing remote file")
+	func testUploadFileWithReplaceExistingOnExistingRemoteFile() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try "hello world".write(to: localURL, atomically: true, encoding: .utf8)
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		try "foo bar".write(to: fileURL, atomically: true, encoding: .utf8)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: true).then { metadata in
-			XCTAssertEqual("file", metadata.name)
-			XCTAssertEqual("/file", metadata.cloudPath.path)
-			XCTAssertEqual(.file, metadata.itemType)
-			XCTAssertNotNil(metadata.lastModifiedDate)
-			XCTAssertEqual(11, metadata.size)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let metadata = try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: true).async()
+		XCTAssertEqual("file", metadata.name)
+		XCTAssertEqual("/file", metadata.cloudPath.path)
+		XCTAssertEqual(.file, metadata.itemType)
+		XCTAssertNotNil(metadata.lastModifiedDate)
+		XCTAssertEqual(11, metadata.size)
 	}
 
-	func testUploadFileWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with itemNotFound error")
+	func testUploadFileWithNotFoundError() async {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).then { _ in
-			XCTFail("Uploading non-existing file should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFileWithAlreadyExistsError() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with itemAlreadyExists error")
+	func testUploadFileWithAlreadyExistsError() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		FileManager.default.createFile(atPath: localURL.path, contents: nil, attributes: nil)
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).then { _ in
-			XCTFail("Uploading file to an existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemAlreadyExists = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemAlreadyExists, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFileWithTypeMismatchError() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with itemTypeMismatch error")
+	func testUploadFileWithTypeMismatchError() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		try FileManager.default.createDirectory(at: localURL, withIntermediateDirectories: false, attributes: nil)
-		provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).then { _ in
-			XCTFail("Uploading file that is actually a folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemTypeMismatch = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.uploadFile(from: localURL, to: CloudPath("/file"), replaceExisting: false).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemTypeMismatch, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFileWithReplaceExistingAndAlreadyExistsError() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with replaceExisting and itemAlreadyExists error")
+	func testUploadFileWithReplaceExistingAndAlreadyExistsError() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		FileManager.default.createFile(atPath: localURL.path, contents: nil, attributes: nil)
 		let fileURL = tmpDirURL.appendingPathComponent("dir", isDirectory: false)
 		try FileManager.default.createDirectory(at: fileURL, withIntermediateDirectories: false, attributes: nil)
-		provider.uploadFile(from: localURL, to: CloudPath("/dir"), replaceExisting: true).then { _ in
-			XCTFail("Uploading and replacing file that is actually a folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemAlreadyExists = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.uploadFile(from: localURL, to: CloudPath("/dir"), replaceExisting: true).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemAlreadyExists, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFileWithParentFolderDoesNotExistError() throws {
-		let expectation = XCTestExpectation(description: "uploadFile with parentFolderDoesNotExist error")
+	func testUploadFileWithParentFolderDoesNotExistError() async throws {
 		let localURL = tmpDirURL.appendingPathComponent(UUID().uuidString, isDirectory: false)
 		FileManager.default.createFile(atPath: localURL.path, contents: nil, attributes: nil)
-		provider.uploadFile(from: localURL, to: CloudPath("/dir/file"), replaceExisting: false).then { _ in
-			XCTFail("Uploading file into a non-existing parent folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.parentFolderDoesNotExist = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.uploadFile(from: localURL, to: CloudPath("/dir/file"), replaceExisting: false).async()) { error in
+			XCTAssertEqual(CloudProviderError.parentFolderDoesNotExist, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testCreateFolder() throws {
-		let expectation = XCTestExpectation(description: "createFolder")
+	func testCreateFolder() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
-		provider.createFolder(at: CloudPath("/dir")).then {
-			var isDirectory: ObjCBool = false
-			XCTAssertTrue(FileManager.default.fileExists(atPath: dirURL.path, isDirectory: &isDirectory))
-			XCTAssertTrue(isDirectory.boolValue)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await provider.createFolder(at: CloudPath("/dir")).async()
+		var isDirectory: ObjCBool = false
+		XCTAssertTrue(FileManager.default.fileExists(atPath: dirURL.path, isDirectory: &isDirectory))
+		XCTAssertTrue(isDirectory.boolValue)
 	}
 
-	func testCreateFolderWithAlreadyExistsError() throws {
-		let expectation = XCTestExpectation(description: "createFolder with itemAlreadyExists error")
+	func testCreateFolderWithAlreadyExistsError() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
 		try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: false, attributes: nil)
-		provider.createFolder(at: CloudPath("/dir")).then {
-			XCTFail("Creating folder at an existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemAlreadyExists = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.createFolder(at: CloudPath("/dir")).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemAlreadyExists, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testCreateFolderWithParentFolderDoesNotExistError() throws {
-		let expectation = XCTestExpectation(description: "createFolder with parentFolderDoesNotExist error")
-		provider.createFolder(at: CloudPath("/dir/dir")).then {
-			XCTFail("Creating folder at a non-existing parent folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.parentFolderDoesNotExist = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+	func testCreateFolderWithParentFolderDoesNotExistError() async {
+		await XCTAssertThrowsErrorAsync(try await provider.createFolder(at: CloudPath("/dir/dir")).async()) { error in
+			XCTAssertEqual(CloudProviderError.parentFolderDoesNotExist, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testDeleteFile() throws {
-		let expectation = XCTestExpectation(description: "deleteFile")
+	func testDeleteFile() async throws {
 		let fileURL = tmpDirURL.appendingPathComponent("file", isDirectory: false)
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
-		provider.deleteFile(at: CloudPath("/file")).then {
-			XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await provider.deleteFile(at: CloudPath("/file")).async()
+		XCTAssertFalse(FileManager.default.fileExists(atPath: fileURL.path))
 	}
 
-	func testDeleteFileWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "deleteFile with itemNotFound error")
-		provider.deleteFile(at: CloudPath("/file")).then {
-			XCTFail("Deleting non-existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+	func testDeleteFileWithNotFoundError() async {
+		await XCTAssertThrowsErrorAsync(try await provider.deleteFile(at: CloudPath("/file")).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testDeleteFolder() throws {
-		let expectation = XCTestExpectation(description: "deleteFolder")
+	func testDeleteFolder() async throws {
 		let dirURL = tmpDirURL.appendingPathComponent("dir", isDirectory: true)
 		try FileManager.default.createDirectory(at: dirURL, withIntermediateDirectories: false, attributes: nil)
 		let fileURL = tmpDirURL.appendingPathComponent("dir/file", isDirectory: false)
 		FileManager.default.createFile(atPath: fileURL.path, contents: nil, attributes: nil)
-		provider.deleteFolder(at: CloudPath("/dir")).then {
-			XCTAssertFalse(FileManager.default.fileExists(atPath: dirURL.path))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await provider.deleteFolder(at: CloudPath("/dir")).async()
+		XCTAssertFalse(FileManager.default.fileExists(atPath: dirURL.path))
 	}
 
-	func testMoveFile() throws {
-		let expectation = XCTestExpectation(description: "moveFile")
+	func testMoveFile() async throws {
 		let sourceURL = tmpDirURL.appendingPathComponent("foo", isDirectory: false)
 		FileManager.default.createFile(atPath: sourceURL.path, contents: nil, attributes: nil)
 		let destinationURL = tmpDirURL.appendingPathComponent("bar", isDirectory: false)
-		provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).then {
-			XCTAssertFalse(FileManager.default.fileExists(atPath: sourceURL.path))
-			XCTAssertTrue(FileManager.default.fileExists(atPath: destinationURL.path))
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		try await provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).async()
+		XCTAssertFalse(FileManager.default.fileExists(atPath: sourceURL.path))
+		XCTAssertTrue(FileManager.default.fileExists(atPath: destinationURL.path))
 	}
 
-	func testMoveFileWithNotFoundError() throws {
-		let expectation = XCTestExpectation(description: "moveFile with itemNotFound error")
-		provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).then {
-			XCTFail("Moving non-existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemNotFound = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+	func testMoveFileWithNotFoundError() async {
+		await XCTAssertThrowsErrorAsync(try await provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemNotFound, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testMoveFileWithAlreadyExistsError() throws {
-		let expectation = XCTestExpectation(description: "moveFile with itemAlreadyExists error")
+	func testMoveFileWithAlreadyExistsError() async {
 		let sourceURL = tmpDirURL.appendingPathComponent("foo", isDirectory: false)
 		FileManager.default.createFile(atPath: sourceURL.path, contents: nil, attributes: nil)
 		let destinationURL = tmpDirURL.appendingPathComponent("bar", isDirectory: false)
 		FileManager.default.createFile(atPath: destinationURL.path, contents: nil, attributes: nil)
-		provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).then {
-			XCTFail("Moving item to an existing item should fail")
-		}.catch { error in
-			guard case CloudProviderError.itemAlreadyExists = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar")).async()) { error in
+			XCTAssertEqual(CloudProviderError.itemAlreadyExists, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testMoveFileWithParentFolderDoesNotExistError() throws {
-		let expectation = XCTestExpectation(description: "moveFile with parentFolderDoesNotExist error")
+	func testMoveFileWithParentFolderDoesNotExistError() async {
 		let sourceURL = tmpDirURL.appendingPathComponent("foo", isDirectory: false)
 		FileManager.default.createFile(atPath: sourceURL.path, contents: nil, attributes: nil)
-		provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar/baz")).then {
-			XCTFail("Moving item to a non-existing parent folder should fail")
-		}.catch { error in
-			guard case CloudProviderError.parentFolderDoesNotExist = error else {
-				XCTFail(error.localizedDescription)
-				return
-			}
-		}.always {
-			expectation.fulfill()
+		await XCTAssertThrowsErrorAsync(try await provider.moveFile(from: CloudPath("/foo"), to: CloudPath("/bar/baz")).async()) { error in
+			XCTAssertEqual(CloudProviderError.parentFolderDoesNotExist, error as? CloudProviderError)
 		}
-		wait(for: [expectation], timeout: 1.0)
 	}
 
 	func testGetItemName() {

--- a/Tests/CryptomatorCloudAccessTests/OneDrive/OneDriveCloudProviderTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/OneDrive/OneDriveCloudProviderTests.swift
@@ -21,7 +21,7 @@ class OneDriveCloudProviderTests: XCTestCase {
 	let maxPageSize = 100
 	override func setUpWithError() throws {
 		let credential = try OneDriveCredential(with: "Test", authProvider: MSAuthenticationProviderMock(), clientApplication: MSALPublicClientApplication())
-		provider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: false, maxPageSize: maxPageSize)
+		provider = try OneDriveCloudProvider(credential: credential, maxPageSize: maxPageSize)
 	}
 
 	func testChildrenRequest() throws {

--- a/Tests/CryptomatorCloudAccessTests/XCTAssertThrowsError+Async.swift
+++ b/Tests/CryptomatorCloudAccessTests/XCTAssertThrowsError+Async.swift
@@ -1,0 +1,25 @@
+//
+//  XCTAssertThrowsError+Async.swift
+//  CryptomatorCloudAccess
+//
+//  Created by Philipp Schmid on 13.04.24.
+//  Copyright © 2024 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+public func XCTAssertThrowsErrorAsync<T>(
+	_ expression: @autoclosure () async throws -> T,
+	_ message: @autoclosure () -> String = "",
+	file: StaticString = #filePath,
+	line: UInt = #line,
+	_ errorHandler: (_ error: any Error) -> Void = { _ in }
+) async {
+	do {
+		_ = try await expression()
+		XCTFail(message(), file: file, line: line)
+	} catch {
+		errorHandler(error)
+	}
+}


### PR DESCRIPTION
This PR adds the ability to inject the unique identifier used by the background `URLSession` for each `CloudProvider`.
This is needed since issues appeared in the FileProviderExtension where we tried to use the same credential, which we usually used to make the identifier unique, for multiple vaults. Therefore, it was possible that more than one background URLSession gets created with the same identifier which then results in a failing URLSession.

Previously we could workaround this issue by just cache each `CloudProvider` but it seems like iOS creates now a own process for each domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced enhanced asynchronous handling capabilities for promises, improving error management and operational efficiency.
- **Tests**
	- Updated testing framework to support asynchronous test functions, ensuring robust error checking and streamlined test execution.
- **Documentation**
	- Enhanced code documentation and project structure to include new asynchronous functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->