### PR TITLE
Migrate from GRDB 5 to GRDB 6

### DIFF
--- a/CryptomatorCloudAccess.xcodeproj/project.pbxproj
+++ b/CryptomatorCloudAccess.xcodeproj/project.pbxproj
@@ -1877,7 +1877,7 @@
 			repositoryURL = "https://github.com/groue/GRDB.swift.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 5.26.0;
+				minimumVersion = 6.29.1;
 			};
 		};
 		74F93565251F6863001F4ADA /* XCRemoteSwiftPackageReference "promises" */ = {

--- a/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CryptomatorCloudAccess.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "dd7e7f39e8e4d7a22d258d9809a882f914690b01",
-        "version" : "5.26.1"
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift.git",
       "state" : {
-        "revision" : "dd7e7f39e8e4d7a22d258d9809a882f914690b01",
-        "version" : "5.26.1"
+        "revision" : "2cf6c756e1e5ef6901ebae16576a7e4e4b834622",
+        "version" : "6.29.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,7 @@ let package = Package(
 		.package(url: "https://github.com/google/GTMAppAuth.git", .upToNextMinor(from: "4.0.0")),
 		.package(url: "https://github.com/google/gtm-session-fetcher.git", .upToNextMinor(from: "3.1.0")),
 		.package(url: "https://github.com/google/promises.git", .upToNextMinor(from: "2.3.0")),
-		.package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMinor(from: "5.26.0")),
+		.package(url: "https://github.com/groue/GRDB.swift.git", .upToNextMinor(from: "6.29.1")),
 		.package(url: "https://github.com/openid/AppAuth-iOS.git", .upToNextMinor(from: "1.6.0")),
 		.package(url: "https://github.com/pCloud/pcloud-sdk-swift.git", .upToNextMinor(from: "3.2.0")),
 		.package(url: "https://github.com/phil1995/dropbox-sdk-obj-c-spm.git", .upToNextMinor(from: "7.2.0")),

--- a/Sources/CryptomatorCloudAccess/Box/BoxIdentifierCache.swift
+++ b/Sources/CryptomatorCloudAccess/Box/BoxIdentifierCache.swift
@@ -13,7 +13,7 @@ class BoxIdentifierCache {
 	private let inMemoryDB: DatabaseQueue
 
 	init() throws {
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: BoxItem.databaseTableName) { table in
 				table.column(BoxItem.cloudPathKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/Box/BoxItem.swift
+++ b/Sources/CryptomatorCloudAccess/Box/BoxItem.swift
@@ -36,7 +36,7 @@ extension BoxItem {
 }
 
 extension BoxItem: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[BoxItem.cloudPathKey] = cloudPath
 		container[BoxItem.identifierKey] = identifier
 		container[BoxItem.itemTypeKey] = itemType

--- a/Sources/CryptomatorCloudAccess/Crypto/DirectoryIdCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/DirectoryIdCache.swift
@@ -19,7 +19,7 @@ private struct CachedEntry: Decodable, FetchableRecord, TableRecord {
 }
 
 extension CachedEntry: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[CachedEntry.cleartextPathKey] = cleartextPath
 		container[CachedEntry.dirIdKey] = dirId
 	}

--- a/Sources/CryptomatorCloudAccess/Crypto/DirectoryIdCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/DirectoryIdCache.swift
@@ -29,7 +29,7 @@ class DirectoryIdCache {
 	private let inMemoryDB: DatabaseQueue
 
 	init() throws {
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: CachedEntry.databaseTableName) { table in
 				table.column(CachedEntry.cleartextPathKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShortenedNameCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShortenedNameCache.swift
@@ -48,7 +48,7 @@ class VaultFormat6ShortenedNameCache {
 	init(vaultPath: CloudPath) throws {
 		self.vaultPath = vaultPath
 		self.ciphertextNameCompIdx = vaultPath.pathComponents.lastItemIndex() + 4
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: CachedEntry.databaseTableName) { table in
 				table.column(CachedEntry.shortenedNameKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShortenedNameCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat6/VaultFormat6ShortenedNameCache.swift
@@ -25,7 +25,7 @@ private struct CachedEntry: Decodable, FetchableRecord, TableRecord {
 }
 
 extension CachedEntry: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[CachedEntry.shortenedNameKey] = shortenedName
 		container[CachedEntry.originalNameKey] = originalName
 	}

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShortenedNameCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShortenedNameCache.swift
@@ -106,7 +106,7 @@ class VaultFormat7ShortenedNameCache {
 		self.vaultPath = vaultPath
 		self.threshold = threshold
 		self.ciphertextNameCompIdx = vaultPath.pathComponents.lastItemIndex() + 4
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: CachedEntry.databaseTableName) { table in
 				table.column(CachedEntry.shortenedNameKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShortenedNameCache.swift
+++ b/Sources/CryptomatorCloudAccess/Crypto/VaultFormat7/VaultFormat7ShortenedNameCache.swift
@@ -31,7 +31,7 @@ private struct CachedEntry: Decodable, FetchableRecord, TableRecord {
 }
 
 extension CachedEntry: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[CachedEntry.shortenedNameKey] = shortenedName
 		container[CachedEntry.originalNameKey] = originalName
 	}

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveIdentifierCache.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveIdentifierCache.swift
@@ -13,7 +13,7 @@ class GoogleDriveIdentifierCache {
 	private let inMemoryDB: DatabaseQueue
 
 	init() throws {
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: GoogleDriveItem.databaseTableName) { table in
 				table.column(GoogleDriveItem.cloudPathKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveIdentifierCache.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveIdentifierCache.swift
@@ -13,7 +13,7 @@ class OneDriveIdentifierCache {
 	private let inMemoryDB: DatabaseQueue
 
 	init() throws {
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: OneDriveItem.databaseTableName) { table in
 				table.column(OneDriveItem.cloudPathKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/OneDrive/OneDriveItem.swift
+++ b/Sources/CryptomatorCloudAccess/OneDrive/OneDriveItem.swift
@@ -42,7 +42,7 @@ struct OneDriveItem: Decodable, FetchableRecord, TableRecord, Equatable {
 }
 
 extension OneDriveItem: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[OneDriveItem.cloudPathKey] = cloudPath
 		container[OneDriveItem.identifierKey] = identifier
 		container[OneDriveItem.driveIdentifierKey] = driveIdentifier

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudIdentifierCache.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudIdentifierCache.swift
@@ -14,7 +14,7 @@ class PCloudIdentifierCache {
 	private let inMemoryDB: DatabaseQueue
 
 	init() throws {
-		self.inMemoryDB = DatabaseQueue()
+		self.inMemoryDB = try DatabaseQueue()
 		try inMemoryDB.write { db in
 			try db.create(table: PCloudItem.databaseTableName) { table in
 				table.column(PCloudItem.cloudPathKey, .text).notNull().primaryKey()

--- a/Sources/CryptomatorCloudAccess/PCloud/PCloudItem.swift
+++ b/Sources/CryptomatorCloudAccess/PCloud/PCloudItem.swift
@@ -46,7 +46,7 @@ extension PCloudItem {
 }
 
 extension PCloudItem: PersistableRecord {
-	func encode(to container: inout PersistenceContainer) {
+	func encode(to container: inout PersistenceContainer) throws {
 		container[PCloudItem.cloudPathKey] = cloudPath
 		container[PCloudItem.identifierKey] = identifier
 		container[PCloudItem.itemTypeKey] = itemType

--- a/Tests/CryptomatorCloudAccessTests/Common/DirectoryContentCacheTests.swift
+++ b/Tests/CryptomatorCloudAccessTests/Common/DirectoryContentCacheTests.swift
@@ -29,7 +29,7 @@ class DirectoryContentCacheTests: XCTestCase {
 	let subfolderPath = CloudPath("/subfolder")
 
 	override func setUpWithError() throws {
-		let inMemoryDB = DatabaseQueue()
+		let inMemoryDB = try DatabaseQueue()
 		cache = try DirectoryContentDBCache(dbWriter: inMemoryDB, maxPageSize: maxPageSize)
 	}
 


### PR DESCRIPTION
Migrate the project from GRDB 5 to GRDB 6, addressing issue #35 by updating database interactions and error handling to align with the latest GRDB changes.