### PR TITLE
Map some individual API errors to CloudProviderError.unauthorized

### DIFF
--- a/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
@@ -579,7 +579,7 @@ public class BoxCloudProvider: CloudProvider {
 
 	private func convertStandardError(_ error: Error) -> Error {
 		switch error {
-		case let error as BoxAPIError where error.responseInfo.statusCode == 401 || error.description.contains("Invalid refresh token"):
+		case let error as BoxAPIError where (error.responseInfo.statusCode == 400 && error.responseInfo.rawBody?.contains("invalid_grant") == true) || error.responseInfo.statusCode == 401:
 			return CloudProviderError.unauthorized
 		case let error as BoxAPIError where error.responseInfo.statusCode == 404:
 			return CloudProviderError.itemNotFound

--- a/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
@@ -579,7 +579,7 @@ public class BoxCloudProvider: CloudProvider {
 
 	private func convertStandardError(_ error: Error) -> Error {
 		switch error {
-		case let error as BoxAPIError where error.responseInfo.statusCode == 400 || error.responseInfo.statusCode == 401:
+		case let error as BoxAPIError where error.responseInfo.statusCode == 401 || error.description.contains("Invalid refresh token"):
 			return CloudProviderError.unauthorized
 		case let error as BoxAPIError where error.responseInfo.statusCode == 404:
 			return CloudProviderError.itemNotFound

--- a/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Box/BoxCloudProvider.swift
@@ -579,7 +579,7 @@ public class BoxCloudProvider: CloudProvider {
 
 	private func convertStandardError(_ error: Error) -> Error {
 		switch error {
-		case let error as BoxAPIError where error.responseInfo.statusCode == 401:
+		case let error as BoxAPIError where error.responseInfo.statusCode == 400 || error.responseInfo.statusCode == 401:
 			return CloudProviderError.unauthorized
 		case let error as BoxAPIError where error.responseInfo.statusCode == 404:
 			return CloudProviderError.itemNotFound

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
@@ -191,7 +191,7 @@ public class DropboxCloudProvider: CloudProvider {
 					return
 				}
 				if let networkError = networkError {
-					CloudAccessDDLogDebug("DropboxCloudProvider: fetchItemMetadata failed with networkError: \(networkError)")
+					CloudAccessDDLogDebug("DropboxCloudProvider: fetchItemMetadata(at: \(cloudPath.path)) failed with networkError: \(networkError)")
 					reject(self.convertRequestError(networkError)) 
 					return
 				}

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxCloudProvider.swift
@@ -192,7 +192,7 @@ public class DropboxCloudProvider: CloudProvider {
 				}
 				if let networkError = networkError {
 					CloudAccessDDLogDebug("DropboxCloudProvider: fetchItemMetadata(at: \(cloudPath.path)) failed with networkError: \(networkError)")
-					reject(self.convertRequestError(networkError)) 
+					reject(self.convertRequestError(networkError))
 					return
 				}
 				guard let result = result else {

--- a/Sources/CryptomatorCloudAccess/Dropbox/DropboxError.swift
+++ b/Sources/CryptomatorCloudAccess/Dropbox/DropboxError.swift
@@ -17,7 +17,6 @@ public enum DropboxError: Error {
 
 	case httpError
 	case badInputError
-	case authError
 	case accessError
 	case pathRootError
 	case rateLimitError(retryAfter: Int)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -533,7 +533,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 					CloudAccessDDLogDebug("GoogleDriveCloudProvider: executeQuery(\(query.requestID)) failed with error: \(error)")
 					if error.domain == NSURLErrorDomain, error.code == NSURLErrorNotConnectedToInternet || error.code == NSURLErrorCannotConnectToHost || error.code == NSURLErrorNetworkConnectionLost || error.code == NSURLErrorDNSLookupFailed || error.code == NSURLErrorResourceUnavailable || error.code == NSURLErrorInternationalRoamingOff {
 						reject(CloudProviderError.noInternetConnection)
-					} else if ((error.domain == kGTLRErrorObjectDomain && (error.code == 401 || error.code == 403)) || (error.domain == OIDOAuthTokenErrorDomain && error.code == -10)) {
+					} else if ((error.domain == kGTLRErrorObjectDomain && (error.code == 401 || error.code == 403)) || (error.domain == OIDOAuthTokenErrorDomain && error.code == OIDErrorCodeOAuth.invalidGrant.rawValue)) {
 						reject(CloudProviderError.unauthorized)
 					} else if error.domain == kGTLRErrorObjectDomain, error.code == 404 {
 						reject(CloudProviderError.itemNotFound)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Skymatic GmbH. All rights reserved.
 //
 
+import AppAuthCore
 import Foundation
 import GoogleAPIClientForREST_Drive
 import GRDB
@@ -532,7 +533,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 					CloudAccessDDLogDebug("GoogleDriveCloudProvider: executeQuery(\(query.requestID)) failed with error: \(error)")
 					if error.domain == NSURLErrorDomain, error.code == NSURLErrorNotConnectedToInternet || error.code == NSURLErrorCannotConnectToHost || error.code == NSURLErrorNetworkConnectionLost || error.code == NSURLErrorDNSLookupFailed || error.code == NSURLErrorResourceUnavailable || error.code == NSURLErrorInternationalRoamingOff {
 						reject(CloudProviderError.noInternetConnection)
-					} else if error.domain == kGTLRErrorObjectDomain || error.domain == "org.openid.appauth.oauth_token", error.code == 401 || error.code == 403 || error.code == -10 {
+					} else if ((error.domain == kGTLRErrorObjectDomain && (error.code == 401 || error.code == 403)) || (error.domain == OIDOAuthTokenErrorDomain && error.code == -10)) {
 						reject(CloudProviderError.unauthorized)
 					} else if error.domain == kGTLRErrorObjectDomain, error.code == 404 {
 						reject(CloudProviderError.itemNotFound)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -533,7 +533,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 					CloudAccessDDLogDebug("GoogleDriveCloudProvider: executeQuery(\(query.requestID)) failed with error: \(error)")
 					if error.domain == NSURLErrorDomain, error.code == NSURLErrorNotConnectedToInternet || error.code == NSURLErrorCannotConnectToHost || error.code == NSURLErrorNetworkConnectionLost || error.code == NSURLErrorDNSLookupFailed || error.code == NSURLErrorResourceUnavailable || error.code == NSURLErrorInternationalRoamingOff {
 						reject(CloudProviderError.noInternetConnection)
-					} else if ((error.domain == kGTLRErrorObjectDomain && (error.code == 401 || error.code == 403)) || (error.domain == OIDOAuthTokenErrorDomain && error.code == OIDErrorCodeOAuth.invalidGrant.rawValue)) {
+					} else if (error.domain == kGTLRErrorObjectDomain && (error.code == 401 || error.code == 403)) || (error.domain == OIDOAuthTokenErrorDomain && error.code == OIDErrorCodeOAuth.invalidGrant.rawValue) {
 						reject(CloudProviderError.unauthorized)
 					} else if error.domain == kGTLRErrorObjectDomain, error.code == 404 {
 						reject(CloudProviderError.itemNotFound)

--- a/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
+++ b/Sources/CryptomatorCloudAccess/GoogleDrive/GoogleDriveCloudProvider.swift
@@ -532,7 +532,7 @@ public class GoogleDriveCloudProvider: CloudProvider {
 					CloudAccessDDLogDebug("GoogleDriveCloudProvider: executeQuery(\(query.requestID)) failed with error: \(error)")
 					if error.domain == NSURLErrorDomain, error.code == NSURLErrorNotConnectedToInternet || error.code == NSURLErrorCannotConnectToHost || error.code == NSURLErrorNetworkConnectionLost || error.code == NSURLErrorDNSLookupFailed || error.code == NSURLErrorResourceUnavailable || error.code == NSURLErrorInternationalRoamingOff {
 						reject(CloudProviderError.noInternetConnection)
-					} else if error.domain == kGTLRErrorObjectDomain, error.code == 401 || error.code == 403 {
+					} else if error.domain == kGTLRErrorObjectDomain || error.domain == "org.openid.appauth.oauth_token", error.code == 401 || error.code == 403 || error.code == -10 {
 						reject(CloudProviderError.unauthorized)
 					} else if error.domain == kGTLRErrorObjectDomain, error.code == 404 {
 						reject(CloudProviderError.itemNotFound)


### PR DESCRIPTION
This update maps specific API authentication errors to CloudProviderError.unauthorized. By standardizing these errors, the app can handle reauthentication more consistently across different cloud providers. This change addresses the requirements in https://github.com/cryptomator/ios/issues/18.